### PR TITLE
OMC tallest

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -55,23 +55,30 @@ holding_torque: 0.63
 max_current: 2.0
 steps_per_revolution: 200
 
-[motor_constants OMC-17HM19-2004S]
+[motor_constants omc-17hm19-2004s]
 resistance: 1.45
 inductance: 0.004
 holding_torque: 0.46
 max_current: 2.0
 steps_per_revolution: 400
 
-[motor_constants OMC-14MS20-1504S]
+[motor_constants omc-14ms20-1504s]
 resistance: 2.80
 inductance: 0.0038
 holding_torque: 0.40
 max_current: 1.50
 steps_per_revolution: 200
 
-[motor_constants OMC-17HS19-2504S-H]
+[motor_constants omc-17hs19-2504s-h]
 resistance: 1.1
 inductance: 0.0016
 holding_torque: 0.55
 max_current: 2.5
+steps_per_revolution: 200
+
+[motor_constants omc-17hs24-2104s]
+resistance: 1.6
+inductance: 0.003
+holding_torque: 0.65
+max_current: 2.1
 steps_per_revolution: 200


### PR DESCRIPTION
According to OMC, "This is the strongest bipolar Nema 17 stepper motor we have". Currently installed in VT.655.