### PR TITLE
Added the standard LGX motor

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -62,6 +62,14 @@ holding_torque: 0.49
 max_current: 1
 steps_per_revolution: 200
 
+[motor_constants ldo-42sth25-1004acg]
+# Bondtech LGX (big) motor that is in fact a rebranded LDO motor
+resistance: 5.5
+inductance: 0.007
+holding_torque: 0.20
+max_current: 1
+steps_per_revolution: 200
+
 ### Moons Motors ###
 
 ## NEMA 14


### PR DESCRIPTION
The title say it all... For the standard "heavy" LGX.

It's a "Bondtech" motor but it's basically a rebranded LDO motor under the hood. So I used the LDO name and added a comment to specify it.