### PR TITLE
Fix "unsupported operand type(s) for <<: 'float' and 'int'" errors

### DIFF
--- a/motor_constants.py
+++ b/motor_constants.py
@@ -20,9 +20,9 @@ class MotorConstants:
     def pwmgrad(self, fclk=12.5e6, steps=0, volts=24.0):
         if steps==0:
             steps=self.S
-        return math.ceil(self.cbemf * 2 * math.pi * fclk  * 1.46 / (volts * 256.0 * steps))
+        return int(math.ceil(self.cbemf * 2 * math.pi * fclk  * 1.46 / (volts * 256.0 * steps)))
     def pwmofs(self, volts=24.0):
-        return math.ceil(374 * self.R * self.L / volts)
+        return int(math.ceil(374 * self.R * self.L / volts))
     # Maximum revolutions per second before PWM maxes out.
     def maxpwmrps(self, fclk=12.5e6, steps=0, volts=24.0):
         if steps==0:
@@ -35,8 +35,8 @@ class MotorConstants:
         dcoilblank = volts * tblank / self.L
         dcoilsd = self.R * I * 2.0 * tsd / self.L
         hstartmin = 0.5 + ((dcoilblank + dcoilsd) * 2 * 248 * 32 / I) / 32 - 8
-        hstrt = min(math.ceil(max(hstartmin + 0.5, -2.0)), 8)
-        hend = min(math.ceil(hstartmin + 0.5) - hstrt, 12)
+        hstrt = min(int(math.ceil(max(hstartmin + 0.5, -2.0))), 8)
+        hend = min(int(math.ceil(hstartmin + 0.5)) - hstrt, 12)
         return hstrt - 1, hend + 3
 
 


### PR DESCRIPTION
Klippy was throwing this error on startup:
```
Internal error during ready callback: unsupported operand type(s) for <<: 'float' and 'int'
Once the underlying issue is corrected, use the
"FIRMWARE_RESTART" command to reset the firmware, reload the
config, and restart the host software.
Printer is shutdown

Script running error
Traceback (most recent call last):
  File "/home/pi/klipper/klippy/extras/delayed_gcode.py", line 34, in _gcode_timer_event
    self.gcode.run_script(self.timer_gcode.render())
  File "/home/pi/klipper/klippy/gcode.py", line 216, in run_script
    self._process_commands(script.split('\n'), need_ack=False)
  File "/home/pi/klipper/klippy/gcode.py", line 198, in _process_commands
    handler(gcmd)
  File "/home/pi/klipper/klippy/gcode.py", line 272, in cmd_default
    raise gcmd.error(self.printer.get_state_message()[0])
```

On python 2, math.ceil returns a float which presumably is used in a way that caused this error; this change fixes it for me.