### PR TITLE
Adding Zyltech 84ozin cheapy steppers

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -279,3 +279,11 @@ inductance: 0.0010
 holding_torque: 0.12
 max_current: 0.5
 steps_per_revolution: 200
+
+[motor_constants zyltech-17hd48002h-22b]
+#Zyltech 84 ozin Basic steppers https://www.zyltech.com/nema-17-stepper-motor-1-7-a-0-59-nm-84-ozin-1-3-or-5-pack/
+resistance: 1.8
+inductance: 0.0038
+holding_torque: 0.59
+max_current: 1.7
+steps_per_revolution: 200


### PR DESCRIPTION
Pulled from the spec sheet here: https://cdn11.bigcommerce.com/s-eblil3q2nd/images/stencil/1280x1280/products/189/16098/Nema17__88326__43441.1665254814.jpg which is included on the product page here: https://www.zyltech.com/nema-17-stepper-motor-1-7-a-0-59-nm-84-ozin-1-3-or-5-pack/

My machine hasn't caught fire yet, but all I did is lift the numbers that appeared correct, so a double check is probably not a terrible call.