### PR TITLE
Automated installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,13 @@ In particular, it enables StealthChop by default on Z motors and extruders, Cool
 
 # Installation
 
-Preparation:
-```
-git clone https://github.com/andrewmcgr/klipper_tmc_autotune.git
-ln -sr klipper_tmc_autotune/autotune_tmc.py $HOME/klipper/klippy/extras/
-ln -sr klipper_tmc_autotune/motor_constants.py $HOME/klipper/klippy/extras/
-ln -sr klipper_tmc_autotune/motor_database.cfg $HOME/printer_data/config/
+To install this plugin, run the installation script using the following command over SSH. This script will download this GitHub repository to your RaspberryPi home directory, and link the files in the Klipper folder.
+
+```bash
+wget -O - https://raw.githubusercontent.com/andrewmcgr/klipper_tmc_autotune/main/install.sh | bash
 ```
 
-Add the following to your printer.cfg, which assumes you have a Voron 2.4. Remove any sections for steppers you don't have (e.g. if you have less than four Z motors), add more if required. Motor names are in the `motor_database.cfg`. If a motor is not listed, add it, taking careful note of the units. PRs for more motors gratefully accepted.
+Then, add the following to your printer.cfg, which assumes you have a Voron 2.4. Remove any sections for steppers you don't have (e.g. if you have less than four Z motors), add more if required. Motor names are in the `motor_database.cfg`. If a motor is not listed, add it, taking careful note of the units. PRs for more motors gratefully accepted.
 ```
 [include motor_database.cfg]
 
@@ -73,5 +71,6 @@ path: ~/klipper_tmc_autotune
 origin: https://github.com/andrewmcgr/klipper_tmc_autotune.git
 managed_services: klipper
 primary_branch: main
+install_script: install.sh
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+KLIPPER_PATH="${HOME}/klipper"
+AUTOTUNETMC_PATH="${HOME}/klipper_tmc_autotune"
+
+set -eu
+export LC_ALL=C
+
+
+function preflight_checks {
+    if [ "$EUID" -eq 0 ]; then
+        echo "[PRE-CHECK] This script must not be run as root!"
+        exit -1
+    fi
+
+    if [ "$(sudo systemctl list-units --full -all -t service --no-legend | grep -F 'klipper.service')" ]; then
+        printf "[PRE-CHECK] Klipper service found! Continuing...\n\n"
+    else
+        echo "[ERROR] Klipper service not found, please install Klipper first!"
+        exit -1
+    fi
+}
+
+function check_download {
+    local autotunedirname autotunebasename
+    autotunedirname="$(dirname ${AUTOTUNETMC_PATH})"
+    autotunebasename="$(basename ${AUTOTUNETMC_PATH})"
+
+    if [ ! -d "${AUTOTUNETMC_PATH}" ]; then
+        echo "[DOWNLOAD] Downloading Autotune TMC repository..."
+        if git -C $autotunedirname clone https://github.com/andrewmcgr/klipper_tmc_autotune.git $autotunebasename; then
+            chmod +x ${AUTOTUNETMC_PATH}/install.sh
+            printf "[DOWNLOAD] Download complete!\n\n"
+        else
+            echo "[ERROR] Download of Autotune TMC git repository failed!"
+            exit -1
+        fi
+    else
+        printf "[DOWNLOAD] Autotune TMC repository already found locally. Continuing...\n\n"
+    fi
+}
+
+function link_extension {
+    echo "[INSTALL] Linking extension to Klipper..."
+    ln -sfn "${AUTOTUNETMC_PATH}/autotune_tmc.py" "${KLIPPER_PATH}/klippy/extras/autotune_tmc.py"
+    ln -sfn "${AUTOTUNETMC_PATH}/motor_constants.py" "${KLIPPER_PATH}/klippy/extras/motor_constants.py"
+}
+
+function restart_klipper {
+    echo "[POST-INSTALL] Restarting Klipper..."
+    sudo systemctl restart klipper
+}
+
+
+printf "\n======================================\n"
+echo "- Autotune TMC install script -"
+printf "======================================\n\n"
+
+
+# Run steps
+preflight_checks
+check_download
+link_extension
+restart_klipper


### PR DESCRIPTION
This is a draft toward an automated installation.

It currently work as is, but there is still a need to include the motor database manually (I wanted to avoid linking the file in the user config folder for now).
Indeed I feel like defaults constants for motors should be integrated and loaded by the extension automatically (from the Klipper folder and not from the user config). Then if one of the motor doesn't exist, the user can still use `[motor_constants some_exotic_motor]` to declare it for himself.

If you don't want that, I can add an automatic link to the motor_constant.cfg as well