### PR TITLE
Added Bondtech LGX and fixed Python error

### DIFF
--- a/autotune_tmc.py
+++ b/autotune_tmc.py
@@ -8,6 +8,7 @@ TRINAMIC_DRIVERS = ["tmc2130", "tmc2208", "tmc2209", "tmc2240", "tmc2660",
 
 class AutotuneTMC:
     def __init__(self, config):
+        self.tmc_section = None
         self.printer = config.get_printer()
         # Load motor databse
         pconfig = self.printer.lookup_object('configfile')

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -107,14 +107,6 @@ holding_torque: 0.18
 max_current: 1
 steps_per_revolution: 200
 
-[motor_constants ldo-42sth25-1004acg]
-# Bondtech LGX (big) motor that is in fact a rebranded LDO motor
-resistance: 5.5
-inductance: 0.007
-holding_torque: 0.20
-max_current: 1
-steps_per_revolution: 200
-
 ### Moons Motors ###
 
 ## NEMA 14
@@ -301,4 +293,12 @@ resistance: 1.8
 inductance: 0.0038
 holding_torque: 0.59
 max_current: 1.7
+steps_per_revolution: 200
+
+[motor_constants bondtech-42H025H-0704A-005]
+#Bondtech LGX https://www.bondtech.se/downloads/TDS/Bondtech-LGX-Motor-42H025H-0704-002.pdf
+resistance: 4.4
+inductance: 0.0055
+holding_torque: 0.16
+max_current: 0.7
 steps_per_revolution: 200

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -107,6 +107,14 @@ holding_torque: 0.18
 max_current: 1
 steps_per_revolution: 200
 
+[motor_constants ldo-42sth25-1004acg]
+# Bondtech LGX (big) motor that is in fact a rebranded LDO motor
+resistance: 5.5
+inductance: 0.007
+holding_torque: 0.20
+max_current: 1
+steps_per_revolution: 200
+
 ### Moons Motors ###
 
 ## NEMA 14

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -340,22 +340,6 @@ holding_torque: 0.48
 max_current: 1.0
 steps_per_revolution: 200
 
-# Creality motors
-
-[motor_constants creality-42-34]
-resistance: 6.0
-inductance: 0.006
-holding_torque: 0.4
-max_current: 1.0
-steps_per_revolution: 200
-
-[motor_constants creality-42-40]
-resistance: 3.6
-inductance: 0.008
-holding_torque: 0.48
-max_current: 1.0
-steps_per_revolution: 200
-
 [motor_constants bondtech-42H025H-0704A-005]
 #Bondtech LGX https://www.bondtech.se/downloads/TDS/Bondtech-LGX-Motor-42H025H-0704-002.pdf
 resistance: 4.4


### PR DESCRIPTION
Hi,
I have added a small fix for the validation of the tmc_sections. In case the validation failed a `Internal error during connect: AutotuneTMC instance has no attribute 'tmc_section'` would be shown.
In addition, I swapped the stepper motor in the database for the normal LGX according to the bond tech website!