### PR TITLE
Retune CoolStep again.

### DIFF
--- a/autotune_tmc.py
+++ b/autotune_tmc.py
@@ -180,7 +180,7 @@ class AutotuneTMC:
         self._set_driver_field('sgt', self.sgt)
         self._set_driver_field('fast_standstill', True)
         self._set_driver_field('small_hysteresis', False)
-        self._set_driver_field('semin', 5)
+        self._set_driver_field('semin', 8)
         self._set_driver_field('semax', 4)
         self._set_driver_field('seup', 3)
         self._set_driver_field('sedn', 0)


### PR DESCRIPTION
`semin` too low ends up causing the occasional missed step at high accelerations.