### PR TITLE
Adding common Oriental Motor motors

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -369,3 +369,35 @@ inductance: 0.0055
 holding_torque: 0.16
 max_current: 0.7
 steps_per_revolution: 200
+
+[motor_constants orientalmotor-PKP245D23A]
+#Oriental Motor PKP245D23A https://catalog.orientalmotor.com/item/all-categories-legacy-products/legacy-pkp-series-2-phase-bipolar-stepper-motors/pkp245d23a
+resistance: 1.12
+inductance: 0.0029
+holding_torque: 0.58
+max_current: 2.3
+steps_per_revolution: 200
+
+[motor_constants orientalmotor-PKP245D15A]
+#Oriental Motor PKP245D15A https://catalog.orientalmotor.com/item/all-categories-legacy-products/legacy-pkp-series-2-phase-bipolar-stepper-motors/pkp245d15a
+resistance: 2.4
+inductance: 0.0066
+holding_torque: 0.58
+max_current: 1.5
+steps_per_revolution: 200
+
+[motor_constants orientalmotor-PKP235D23A]
+#Oriental Motor PKP235D23A https://catalog.orientalmotor.com/item/2-phase-bipolar-stepper-motors/35mm-pkp-series-2-phase-bipolar-stepper-motors/pkp235d23a-l
+resistance: 0.97
+inductance: 0.0012
+holding_torque: 0.37
+max_current: 2.3
+steps_per_revolution: 200
+
+[motor_constants orientalmotor-PKP235D15A]
+#Oriental Motor PKP235D15A https://catalog.orientalmotor.com/item/2-phase-bipolar-stepper-motors/35mm-pkp-series-2-phase-bipolar-stepper-motors/pkp235d15a-l
+resistance: 2.4
+inductance: 0.0026
+holding_torque: 0.37
+max_current: 1.5
+steps_per_revolution: 200


### PR DESCRIPTION
PKP245D23A is a legacy, 2.3A high-torque motor. Quite uncommon in general but a common NEMA17 motor from Oriental Motor. I have also added the 1.5 version.

I currently run 4x PKP245D23A for my Voron 2.4 for the Z axis. The high torque equates to almost no gantry sag when the printer is turned off. I have run the 2x PKP245D15A on the rear before upgrading to PKP245D23A for all 4 motors.

PKP235D23A is a NEMA 14 motor (with an odd hole spacing) that I currently run in my Voron 0.

There is an updated PKP235D23A2 motor but I have not tested that motor yet.