### PR TITLE
Update motor_database.cfg - added omc-17hm19-1684S

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -253,6 +253,13 @@ steps_per_revolution: 200
 
 ## NEMA 17
 
+[motor_constants omc-17hm19-1684S]
+resistance: 1.65
+inductance: 0.0041
+holding_torque: 0.44
+max_current: 1.68
+steps_per_revolution: 400
+
 [motor_constants omc-17hm19-2004s]
 resistance: 1.45
 inductance: 0.004


### PR DESCRIPTION
https://www.omc-stepperonline.com/de/nema-17-bipolar-0-9-grad-44ncm-62-3oz-in-1-68a-2-8v-42x42x47mm-4-draehte-17hm19-1684s