### PR TITLE
Update  ldo-35-sth52-1504ah & Add ldo-42sth40-1684ac

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -25,7 +25,7 @@ steps_per_revolution: 200
 
 [motor_constants ldo-35sth52-1504ah]
 resistance: 2.8
-inductance: 0.038
+inductance: 0.0038
 holding_torque: 0.37
 max_current: 1.5
 steps_per_revolution: 200
@@ -52,6 +52,13 @@ steps_per_revolution: 200
 #Trident Z motor kit from LDO
 resistance: 1.65
 inductance: 0.0041
+holding_torque: 0.45
+max_current: 1.68
+steps_per_revolution: 200
+
+[motor_constants ldo-42sth40-1684ac]
+resistance: 1.65
+inductance: 0.0036
 holding_torque: 0.45
 max_current: 1.68
 steps_per_revolution: 200


### PR DESCRIPTION
Added specs for the LDO-42STH40-1684AC motor as well (used in LDO Micron+ Kit)

Corrected the mH value for the LDO-35STH52-1504AH
This was incorrectly set as 0.038, it should be 0.0038 for 3.8mH, as stated on the spec sheet.

