### PR TITLE
Add Fysetc G36HSY4407-6D-1200A

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -377,6 +377,13 @@ holding_torque: 0.11
 max_current: 1.0
 steps_per_revolution: 200
 
+[motor_constants fysetc-g36hsy4407-6d-1200a]
+resistance: 13
+inductance:  0.01
+holding_torque: 0.12
+max_current: 0.5
+steps_per_revolution: 200
+
 [motor_constants fysetc-35hsh7402-24b-60a]
 resistance: 2.8
 inductance: 0.0055


### PR DESCRIPTION
Add G36HSY4407-6D-1200A from Fysetc (sheet available here : https://github.com/FYSETC/FYSETC-MOTORS/blob/main/G36HSY4407-6D-1200A/G36HSY4407-6D-1200A.pdf )
This motor was used in their Galileo 1.0 kits