### PR TITLE
Add Fysetc g36hsy4405-6d-30

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -377,6 +377,13 @@ holding_torque: 0.11
 max_current: 1.0
 steps_per_revolution: 200
 
+[motor_constants fysetc-g36hsy4405-6d-30]
+resistance: 2.4
+inductance:  0.0017
+holding_torque: 0.11
+max_current: 1.0
+steps_per_revolution: 200
+
 [motor_constants fysetc-35hsh7402-24b-60a]
 resistance: 2.8
 inductance: 0.0055


### PR DESCRIPTION
Add Fysetc g36hsy4405-6d-30 motor (used in their Stealthburner kits)

The sheet is available here : https://github.com/FYSETC/FYSETC-MOTORS/blob/main/G36HSY4405-6D-30/G36HSY4405-6D-30%EF%BC%88FYSETC%EF%BC%89.pdf