### PR TITLE
allow get_current() to return more values

### DIFF
--- a/autotune_tmc.py
+++ b/autotune_tmc.py
@@ -190,7 +190,8 @@ class AutotuneTMC:
         self.tune_driver()
 
     def tune_driver(self, print_time=None):
-        self.run_current, _, _, _ = self.tmc_cmdhelper.current_helper.get_current()
+        _currents = self.tmc_cmdhelper.current_helper.get_current()
+        self.run_current = _currents[0]
         self._set_hysteresis(self.run_current)
         self._set_pwmfreq()
         self._set_sg4thrs()


### PR DESCRIPTION
Hi :)

[Danger-Klipper](https://github.com/DangerKlippers/danger-klipper) now supports [`home_current`](https://github.com/DangerKlippers/danger-klipper/pull/65), so the `get_current()` method has an extra value to return.
This PR doesn't change any functionality or new behaviour to `klipper_tmc_autotune` but allows users running Danger-Klipper to use it.