### PR TITLE
Motor constants for Siboor 35HBX904-22B

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -460,6 +460,14 @@ holding_torque: 0.36
 max_current: 1.2
 steps_per_revolution: 200
 
+[motor_constants siboor-35hbx904-22b]
+#Siboor BOM Voron 0.1 Young edition steppers
+resistance: 2.50
+inductance: 0.0043
+holding_torque: 0.40
+max_current: 1.50
+steps_per_revolution: 200
+
 # Creality motors
 
 [motor_constants creality-42-34]


### PR DESCRIPTION
Motor constants for Siboor 35HBX904-22B, used in Voron 0.1 Young edition

official specs from: https://discord.com/channels/1030697720312234054/1031541938043768902/1167287064849547375