### PR TITLE
Bugfix for AUTOTUNE_TMC

### DIFF
--- a/autotune_tmc.py
+++ b/autotune_tmc.py
@@ -150,7 +150,7 @@ class AutotuneTMC:
     cmd_AUTOTUNE_TMC_help = "Apply autotuning configuration to TMC stepper driver"
     def cmd_AUTOTUNE_TMC(self, gcmd):
         logging.info("AUTOTUNE_TMC %s", self.name)
-        tgoal = gcmd.get('TUNING_GOAL', TUNING_GOAL).lower()
+        tgoal = gcmd.get('TUNING_GOAL', None)
         if tgoal is not None:
             try:
                 self.tuning_goal = TuningGoal(tgoal)


### PR DESCRIPTION
When using the command AUTOTUNE_TMC without a TUNING_GOAL parameter it defaulted to the constant TUNING_GOAL = 'auto'.
If the parameter is not set it will change the mode of the stepper to 'auto' instead of keeping the current one.
self.tgoal is initialized with default auto in class constructor and there should not be a case where it is not already set.

Expected behaviour is not changing self.tgoal if not specified to.