### PR TITLE
Update motor_database.cfg with HoneyBadger 42HS48-25044A from Fabreeko

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -532,6 +532,14 @@ holding_torque: 0.12
 max_current: 0.5
 steps_per_revolution: 200
 
+[motor_constants honeybadger-42hs48-25044a]
+#HoneyBadger by Fabreeko 42HS48-25044A https://www.fabreeko.com/collections/honeybadger/products/zero-g-ab-motors-by-honeybadger?variant=43510563176703
+resistance: 1.6
+inductance: 0.0018
+holding_torque: 0.49
+max_current: 2.5
+steps_per_revolution: 200
+
 # Motech motors
 
 [motor_constants motech-mt-1701hsm140ae]


### PR DESCRIPTION
Added the HoneyBadger 42HS48-25044A (Common in fabreeko kits) to the motor database. Data was pulled from the spec sheet posted in the ZeroG discord server by someone who works at Fabreeko

Link to the spec sheet:

https://cdn.discordapp.com/attachments/907227569689096222/1174058270625902752/hb_motors.png?ex=656635f8&is=6553c0f8&hm=3af5eccabb4c1f6b405ed810dd9160eadeae3a2fa32edb563b3fe75a73f3f597&