### PR TITLE
QOL- forcing lowercase when reading motorname from config

### DIFF
--- a/autotune_tmc.py
+++ b/autotune_tmc.py
@@ -88,7 +88,7 @@ class AutotuneTMC:
                 % (self.name))
 
         # AutotuneTMC config parameters
-        self.motor = config.get('motor')
+        self.motor = config.get('motor').lower()
         self.motor_name = "motor_constants " + self.motor
         try:
             motor = self.printer.lookup_object(self.motor_name)


### PR DESCRIPTION
added forcing lowercase motorname when reading from config