### PR TITLE
Add Wantai 42BYGHW811-X11 and OMC 17HE19-2004S

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -296,6 +296,13 @@ holding_torque: 0.42
 max_current: 1.50
 steps_per_revolution: 200
 
+[motor_constants omc-17he19-2004s]
+resistance: 1.30
+inductance: 0.0024
+holding_torque: 0.55
+max_current: 2.0
+steps_per_revolution: 200
+
 [motor_constants omc-17hs15-1504s]
 resistance: 2.30
 inductance: 0.0044
@@ -488,6 +495,14 @@ resistance: 2.50
 inductance: 0.0043
 holding_torque: 0.40
 max_current: 1.50
+steps_per_revolution: 200
+
+[motor_constants wantai-42byghw811]
+# Wantai Stepper Motor 42BYGHW811 and 42BYGHW811-X11
+resistance: 1.25
+inductance: 0.0018
+holding_torque: 0.48
+max_current: 2.50
 steps_per_revolution: 200
 
 # Creality motors


### PR DESCRIPTION
Add information for 2 steppers:

- Wantai 42BYGHW811-X11, which is a variant of 42BYGHW811
- OMC StepperOnline 17HE19-2004S, which is a 1.8 degree variant of 17HM19-2004S