### PR TITLE
Fixed typo in motor_database.py

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -667,7 +667,7 @@ holding_torque: 0.40
 max_current: 1.70
 steps_per_revolution: 200
 
-[motor_constance trianglelab-tl-42bygh20]
+[motor_constants trianglelab-tl-42bygh20]
 # ERCF v1.1 kit motor (NEMA 17)
 resistance: 6.8
 inductance: 0.0071


### PR DESCRIPTION
Fixed typo preventing Klippy from loading in motor_database.py, [motor_constants trianglelab-tl-42bygh20] section