### PR TITLE
Update motor_database.cfg for Creality Sprite Pro

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -514,6 +514,14 @@ holding_torque: 0.57
 max_current: 1.0
 steps_per_revolution: 200
 
+[motor_constants BJ42D09-20V02]
+#Creality Sprite Pro https://user-images.githubusercontent.com/862951/235050029-79124b76-81d3-4f77-9501-6404f7c38336.png
+resistance: 1.75
+inductance: 0.003
+holding_torque: 0.15
+max_current: 0.84
+steps_per_revolution: 200
+
 [motor_constants bondtech-42H025H-0704A-005]
 #Bondtech LGX https://www.bondtech.se/downloads/TDS/Bondtech-LGX-Motor-42H025H-0704-002.pdf
 resistance: 4.4


### PR DESCRIPTION
Adding constants for the Creality Sprite Pro extruder which uses motor BJ42D09-20V02. Comes as default with the Ender 3 S1 and is upgradable on other Ender 3 series machines.