### PR TITLE
Fix capitalization of motor definitions

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -237,14 +237,14 @@ holding_torque: 0.054
 max_current: 0.65
 steps_per_revolution: 200
 
-[motor_constants moons-ms17hd6p420I-04]
+[motor_constants moons-ms17hd6p420i-04]
 resistance: 1.3
 inductance: 0.0027
 holding_torque: 0.67
 max_current: 2.0
 steps_per_revolution: 200
 
-[motor_constants moons-ms17hd6p420I-05]
+[motor_constants moons-ms17hd6p420i-05]
 resistance: 1.3
 inductance: 0.0027
 holding_torque: 0.67
@@ -303,7 +303,7 @@ holding_torque: 0.45
 max_current: 1.50
 steps_per_revolution: 200
 
-[motor_constants omc-17hm19-1684S]
+[motor_constants omc-17hm19-1684s]
 resistance: 1.65
 inductance: 0.0041
 holding_torque: 0.44
@@ -415,7 +415,7 @@ max_current: 0.4
 steps_per_revolution: 200
 
 
-[motor_constants TB-3544]
+[motor_constants tb-3544]
 #Fysetc bom Voron 2.4 steppers
 resistance: 1.8
 inductance: 0.0038
@@ -423,7 +423,7 @@ holding_torque: 0.50
 max_current: 1.5
 steps_per_revolution: 200
 
-[motor_constants fysetc-17HS19-2004S-C]
+[motor_constants fysetc-17hs19-2004s-c]
 #Fysetc bom Trident A/B steppers
 resistance: 1.4
 inductance: 0.003
@@ -431,7 +431,7 @@ holding_torque: 0.59
 max_current: 2.0
 steps_per_revolution: 200
 
-[motor_constants fysetc-42HC40-204A-300N84]
+[motor_constants fysetc-42hc40-204a-300n84]
 #Fysetc bom Trident Z integrated leadscrew steppers
 resistance: 1.1
 inductance: 0.0026
@@ -514,7 +514,7 @@ holding_torque: 0.57
 max_current: 1.0
 steps_per_revolution: 200
 
-[motor_constants bondtech-42H025H-0704A-005]
+[motor_constants bondtech-42h025h-0704a-005]
 #Bondtech LGX https://www.bondtech.se/downloads/TDS/Bondtech-LGX-Motor-42H025H-0704-002.pdf
 resistance: 4.4
 inductance: 0.0055
@@ -522,7 +522,7 @@ holding_torque: 0.16
 max_current: 0.7
 steps_per_revolution: 200
 
-[motor_constants orientalmotor-PKP245D23A]
+[motor_constants orientalmotor-pkp245d23a]
 #Oriental Motor PKP245D23A https://catalog.orientalmotor.com/item/all-categories-legacy-products/legacy-pkp-series-2-phase-bipolar-stepper-motors/pkp245d23a
 resistance: 1.12
 inductance: 0.0029
@@ -530,7 +530,7 @@ holding_torque: 0.58
 max_current: 2.3
 steps_per_revolution: 200
 
-[motor_constants orientalmotor-PKP245D15A]
+[motor_constants orientalmotor-pkp245d15a]
 #Oriental Motor PKP245D15A https://catalog.orientalmotor.com/item/all-categories-legacy-products/legacy-pkp-series-2-phase-bipolar-stepper-motors/pkp245d15a
 resistance: 2.4
 inductance: 0.0066
@@ -538,7 +538,7 @@ holding_torque: 0.58
 max_current: 1.5
 steps_per_revolution: 200
 
-[motor_constants orientalmotor-PKP235D23A]
+[motor_constants orientalmotor-pkp235d23a]
 #Oriental Motor PKP235D23A https://catalog.orientalmotor.com/item/2-phase-bipolar-stepper-motors/35mm-pkp-series-2-phase-bipolar-stepper-motors/pkp235d23a-l
 resistance: 0.97
 inductance: 0.0012
@@ -546,7 +546,7 @@ holding_torque: 0.37
 max_current: 2.3
 steps_per_revolution: 200
 
-[motor_constants orientalmotor-PKP235D15A]
+[motor_constants orientalmotor-pkp235d15a]
 #Oriental Motor PKP235D15A https://catalog.orientalmotor.com/item/2-phase-bipolar-stepper-motors/35mm-pkp-series-2-phase-bipolar-stepper-motors/pkp235d15a-l
 resistance: 2.4
 inductance: 0.0026
@@ -628,7 +628,7 @@ holding_torque: 0.804
 max_current: 2.0
 steps_per_revolution: 200
 
-[motor_constants BTT-17H4401S]
+[motor_constants btt-17h4401s]
 #BTT 17H4401S lead screw motor
 resistance: 2.40
 inductance: 0.0037


### PR DESCRIPTION
This PR solves the issue caused by #98 that did not update the actual motor database itself to ensure that lowercase is used consistently across all components.