### PR TITLE
Added stepper motor to database

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -251,6 +251,14 @@ holding_torque: 0.67
 max_current: 2.0
 steps_per_revolution: 200
 
+# Comes stock on many older Creality printers, e.g: Ender 3, V2, Max
+[motor_constants moons-c17hd2024n-01n]
+resistance: 4.1
+inductance: 0.0085
+holding_torque: 0.39
+max_current: 1.0
+steps_per_revolution: 200
+
 ### OMC Stepperonline ###
 
 ## NEMA 14


### PR DESCRIPTION
Added Moons' stepper motor that came stock on many, older Creality printers (e.g: E3, E3Pro, E3V2, E3Max, E5)