### PR TITLE
add Stepperonline (OMC) 14HR07-1004VRN motor to the database

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -277,6 +277,13 @@ holding_torque: 0.4
 max_current: 1.5
 steps_per_revolution: 200
 
+[motor_constants omc-14hr07-1004vrn]
+resistance: 3.9
+inductance: 0.002
+holding_torque: 0.09
+max_current: 1.00
+steps_per_revolution: 400
+
 # Adding the two stepper motors for the original V0 release:
 # OMC 14HS17-0504S (A/B/Z)
 # OMC 14HS10-0404S (Clockwork)


### PR DESCRIPTION
add 14HR07-1004VRN Nema 14 motor which is used in Voron's stealthburner
specs is [here](https://www.omc-stepperonline.com/round-nema-14-bipolar-0-9deg-9-ncm-12-75-oz-in-1-0a-%CF%8636x17-5mm-4-wires-14hr07-1004vrn)
thank you

