### PR TITLE
Update motor_database.cfg

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -559,6 +559,14 @@ holding_torque: 0.57
 max_current: 1.0
 steps_per_revolution: 200
 
+[motor_constants creality-42-60]
+#Creality Ender 7 (X,Y) - RB Step Motor 17HDC8033-32B - https://14.23.50.34/en/biaozhunshihunheshibujindianji/41
+resistance: 1.2
+inductance: 0.0034
+holding_torque: 0.76
+max_current: 2.00
+steps_per_revolution: 200
+
 [motor_constants BJ42D09-20V02]
 #Creality Sprite Pro https://user-images.githubusercontent.com/862951/235050029-79124b76-81d3-4f77-9501-6404f7c38336.png
 resistance: 1.75


### PR DESCRIPTION
Added motor from Ender 7 - 17HDC8033-32B
Brand: RB MOTOR
Model: 17HDC8033-32B
Link:  https://14.23.50.34/en/biaozhunshihunheshibujindianji/41

[motor_constants creality 42-60] 
#Creality Ender 7 - RB Step Motor 17HDC8033-32B 
# Coil resistance, Ohms
resistance: 1.2
# Coil inductance, Henries
inductance: 0.0034
# Holding torque, Nm
holding_torque: 0.76
# Nominal rated current, Amps
max_current: 2.00
# Steps per revolution (1.8deg motors)
steps_per_revolution: 200