### PR TITLE
Add D42HS3418-24B22, 17HS4023, 42BYG011-25 to motor.db

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -750,3 +750,28 @@ inductance: 0.0028
 holding_torque: 0.65
 max_current: 2
 steps_per_revolution: 200
+
+[motor_constants geetech-d42hs3418-24b22]
+#ShenZhen Geetech Technology Nema 17 extruder motor, e.g. A20M
+resistance: 1.65
+inductance: 0.0032
+holding_torque: 0.4
+max_current: 1.68
+steps_per_revolution: 200
+
+[motor_constants usongshine-17hs4023]
+#Generic Usongshine Nema 17 Pancake Stepper 
+resistance: 4
+inductance: 0.0032
+holding_torque: 0.14
+max_current: 0.7
+steps_per_revolution: 200
+
+[motor_constants mercury-42byg011-25]
+#Generic Mercuy Stepper Motor
+resistance: 3.4
+inductance: 0.046
+holding_torque: 0.23
+max_current: 0.33
+steps_per_revolution: 200
+


### PR DESCRIPTION
Data for D42HS3418-24B22 from https://www.amazon.de/-/en/Stepper-Printer-Extruder-Degree-D42HS3418-24B22/dp/B0BNHJVFRJ :

![image](https://github.com/andrewmcgr/klipper_tmc_autotune/assets/6112968/7cbc48d5-5428-4db7-9298-5a228e4f2fb0)

Data for 17HS4023 from https://abra-electronics.com/electromechanical/motors/stepper-motors/nema-17/mot-17hs4023-17hs4023-nema-17-43mm-1.8a-dual-phase-stepper-motor-1.8.html

```
Specifications

Phase: 2-phase step drive.
Step angle: 1.8 ± 5% °/Step.
Voltage: 12V.
Current: 700 mA/phase.
Resistance: 4 ± 10% Ω/Phase.
Inductance: 3.2 ± 20% mH/Phase.
Holding Torque: 14 N.cm (1.24 lb.in).
Detent Torque: 2.2 N.cm (0.2 lb.in).
Rotational Inertia: 54 g.cm² (0.3 oz.in²).
Insulation Class: B (see table below for temperatures).
Ambient Temperature Required: -20 to 50°C (-4 to 122°F).
Pinout: Red = A+.
Green = A.
Black = B+.
Blue = B.
*The two unused pins are “common pins” and are used in uni-polar mode..
Body Dimensions: 41.8 x 41.8 x 23.8 mm (1.65 x 1.65” x 0.94”).
Shaft Diameter: 5mm.
Shaft Length: 21mm.
Weight: 130g (4.6 oz.).
```

Data for SM-42BYG011-25 from https://www.sparkfun.com/datasheets/Robotics/SM-42BYG011-25.pdf

![image](https://github.com/andrewmcgr/klipper_tmc_autotune/assets/6112968/17a5af01-c317-4897-9b0f-6350a6d190f2)
