### PR TITLE
Added StepperOnline Nema 14 pancake motor 14RE08-1004S-H

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -750,3 +750,10 @@ inductance: 0.0028
 holding_torque: 0.65
 max_current: 2
 steps_per_revolution: 200
+
+[motor_constants stepperonline-nema-14re08-1004s-h]
+resistance: 2.1
+inductance: 0.0011
+holding_torque: 0.1
+max_current: 1.00
+steps_per_revolution: 200


### PR DESCRIPTION
This motor was received with Siboor's v0.2r1 (August update) kit.

The specs were found here: https://www.omc-stepperonline.com/nema-14-high-temp-stepper-motor-10ncm-14-24oz-in-insulation-class-h-180c-14re08-1004s-h