### PR TITLE
Inclusion of 42SHDC3025-24B stepper on  motor_database.cfg

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -757,3 +757,22 @@ inductance: 0.0028
 holding_torque: 0.65
 max_current: 2
 steps_per_revolution: 200
+
+
+
+[motor_constants 42SHDC3025-24B]
+#ANET ET4 A8 Default XYZE motors
+#As taken from: https://shop.anet3d.com/collections/electronic-accessories/products/42-stepper-motor  Avaliable values ( max_current , holding_torque, steps_per_revolution )
+#And https://3dprint.wiki/reprap/anet/a8/steppermotor                                                 Avaliable values ( max_current , holding_torque, steps_per_revolution, resistance )
+#And https://reprap.pt/pecas/motores-de-passos/573-anet-motor-nema-17-42shdc3025-24b                  Avaliable values ( max_current , holding_torque )
+#Sources for inductance extrapolation:
+#https://ww1.microchip.com/downloads/en/DeviceDoc/Leedshine%2042HS03%20Stepper%20Motor%20Datasheet.pdf
+#https://reprap.pt/loja/produto/?id=957
+#https://3dprint.wiki/reprap/anet/a8/steppermotor
+#https://reprap.org/wiki/NEMA_17_Stepper_motor
+resistance: 4.4
+inductance: 0.0032    # Extrapolated from other sources and similar models. (42SHDC3025-24B stepper motor is estimated to be between 3.0 and 4.4, using SL42STH40-1204A as best guess setting to 3.2  )
+holding_torque: 0.4
+max_current: 0.9
+steps_per_revolution: 200
+


### PR DESCRIPTION
Inclusion of  42SHDC3025-24B on motor_database.cfg
ANET ET4/A8 Default XYZE motors

Rerefences used:
 * https://shop.anet3d.com/collections/electronic-accessories/products/42-stepper-motor  
       ( max_current , holding_torque, steps_per_revolution )
*https://3dprint.wiki/reprap/anet/a8/steppermotor  
       ( max_current , holding_torque, steps_per_revolution, resistance )
 *https://reprap.pt/pecas/motores-de-passos/573-anet-motor-nema-17-42shdc3025-24b     
       ( max_current , holding_torque, used to extrapolate Induction )