### PR TITLE
Add QIDI X MAX 3 motors to motor database

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -544,11 +544,18 @@ steps_per_revolution: 200
 
 # QIDI motors
 
-[motor_constants qidi-42-48]
+[motor_constants qidi-BJ42D29-28V07] # used for X/Y-axis on QIDI X MAX 3
 resistance: 1.4
-inductance: 0.026
+inductance: 0.0026
 holding_torque: 0.41
 max_current: 1.5
+steps_per_revolution: 200
+
+[motor_constants qidi-BJ42D29-22V08] # used for Z-Axis on QIDI X MAX 3
+resistance: 4.7
+inductance: 0.011
+holding_torque: 0.6
+max_current: 1.2
 steps_per_revolution: 200
 
 # Creality motors

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -544,14 +544,16 @@ steps_per_revolution: 200
 
 # QIDI motors
 
-[motor_constants qidi-BJ42D29-28V07] # used for X/Y-axis on QIDI X MAX 3
+[motor_constants qidi-BJ42D29-28V07]
+# used for X/Y-axis on QIDI X MAX 3
 resistance: 1.4
 inductance: 0.0026
 holding_torque: 0.41
 max_current: 1.5
 steps_per_revolution: 200
 
-[motor_constants qidi-BJ42D29-22V08] # used for Z-Axis on QIDI X MAX 3
+[motor_constants qidi-BJ42D29-22V08]
+# used for Z-Axis on QIDI X MAX 3
 resistance: 4.7
 inductance: 0.011
 holding_torque: 0.6

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -542,6 +542,15 @@ holding_torque: 0.48
 max_current: 2.50
 steps_per_revolution: 200
 
+# QIDI motors
+
+[motor_constants qidi-42-48]
+resistance: 1.4
+inductance: 0.026
+holding_torque: 0.41
+max_current: 1.5
+steps_per_revolution: 200
+
 # Creality motors
 
 [motor_constants creality-42-34]

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -560,6 +560,14 @@ holding_torque: 0.6
 max_current: 1.2
 steps_per_revolution: 200
 
+[motor_constants qidi-BJY36D12-04V13]
+# used for extruder on QIDI X MAX 3
+resistance: 2.0
+inductance: 0.0012
+holding_torque: 0.09
+max_current: 1.0
+steps_per_revolution: 200
+
 # Creality motors
 
 [motor_constants creality-42-34]


### PR DESCRIPTION
I asked QIDI for specifications, got the data sheets from them and added the X/Y/Z-axis motor specs to the motor database.
Reference:
![grafik](https://github.com/andrewmcgr/klipper_tmc_autotune/assets/66898912/ac1a2195-0ef8-41c9-b5b4-c2744447322e)
![grafik](https://github.com/andrewmcgr/klipper_tmc_autotune/assets/66898912/92ca6b28-69a3-4d95-9abf-1cf9e4ad7499)
