### PR TITLE
Update motor_database.cfg Fysetc voron 0.2 R1 kit & remove duplicates

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -120,13 +120,6 @@ holding_torque: 0.44
 max_current: 2.0
 steps_per_revolution: 400
 
-[motor_constants ldo-42sth48-2004ac]
-resistance: 1.6
-inductance: 0.003
-holding_torque: 0.59
-max_current: 2.0
-steps_per_revolution: 200
-
 [motor_constants ldo-42sth40-1004a]
 #Prusa Mk3 steppers XYE axis
 #https://cfl.prusa3d.com/display/PI3M3/Stepper+motors
@@ -143,12 +136,6 @@ holding_torque: 0.39
 max_current: 1
 steps_per_revolution: 400
 
-[motor_constants ldo-42sth40-2004mah]
-resistance: 1.1
-inductance: 0.0028
-holding_torque: 0.35
-max_current: 2
-steps_per_revolution: 400
 
 [motor_constants ldo-42sth20-1004ash]
 resistance: 7.2
@@ -318,12 +305,6 @@ holding_torque: 0.42
 max_current: 1.50
 steps_per_revolution: 200
 
-[motor_constants omc-17he19-2004s]
-resistance: 1.30
-inductance: 0.0024
-holding_torque: 0.55
-max_current: 2.0
-steps_per_revolution: 200
 
 [motor_constants omc-17hs15-1504s]
 resistance: 2.30
@@ -440,6 +421,20 @@ resistance: 2.8
 inductance: 0.0055
 holding_torque: 0.42
 max_current: 1.5
+steps_per_revolution: 200
+
+[motor_constants fysetc-35hsh7402-24b-60b]
+resistance: 2.8
+inductance: 0.0055
+holding_torque: 0.42
+max_current: 1.5
+steps_per_revolution: 200
+
+[motor_constants fysetc-42hsc1433b-200n8]
+resistance: 8
+inductance: 0.01
+holding_torque: 0.35
+max_current: 1
 steps_per_revolution: 200
 
 #NEMA 17


### PR DESCRIPTION
Added the missing motors according to the datasheets ( [https://github.com/FYSETC/FYSETC-Voron-0.2-Pro/tree/main/0.2%20R1%20V1.1/Docs/Stepper%20motor%20parameters](url) ) and removed 3 duplicates motors-constants sections.