### PR TITLE
Update motor_database.cfg for ldo-42sth40-1684cl350et

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -55,6 +55,14 @@ steps_per_revolution: 200
 
 ## NEMA 17
 
+[motor_constants ldo-42sth40-1684cl350et]
+#Trident Z motor kit from LDO
+resistance: 1.65
+inductance: 0.0041
+holding_torque: 0.45
+max_current: 2.0
+steps_per_revolution: 200
+
 [motor_constants ldo-42sth40-1684l300e]
 #Trident Z motor kit from LDO
 resistance: 1.65


### PR DESCRIPTION
Add constants for ldo-42sth40-1684cl350et.

It differs from ldo-42sth40-1684l300e only in its max current. Not sure if that warrants a new entry. But at least it's easier to find.

Datasheet: https://www.onetwo3d.co.uk/wp-content/uploads/2021/04/VRN_LDO-42STH40-1684CL350ET_VRN_RevA.pdf