### PR TITLE
Adding Siboor steppers and sort them

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -503,19 +503,20 @@ holding_torque: 0.59
 max_current: 1.7
 steps_per_revolution: 200
 
+[motor_constants siboor-14sth20-1004a]
+#Siboor BOM Voron Trident AWD
+resistance: 1.7
+inductance: 0.0015
+holding_torque: 0.12
+max_current: 1.88
+steps_per_revolution: 200
+
 [motor_constants siboor-35sth52-1204a]
 #Siboor BOM Voron 0.2 steppers
 resistance: 2.3
 inductance: 0.0035
 holding_torque: 0.4
 max_current: 1.2
-steps_per_revolution: 200
-
-[motor_constants siboor-42sth40-2004a]
-resistance: 1.1
-inductance: 0.0026
-holding_torque: 0.45
-max_current: 2.0
 steps_per_revolution: 200
 
 [motor_constants siboor-35hbx904-22b]
@@ -532,6 +533,21 @@ resistance: 5.5
 inductance: 0.0066
 holding_torque: 0.26
 max_current: 1.0
+steps_per_revolution: 200
+
+[motor_constants siboor-42sth40-2004a]
+resistance: 1.1
+inductance: 0.0026
+holding_torque: 0.45
+max_current: 2.0
+steps_per_revolution: 200
+
+[motor_constants siboor-42sth48-2504(s45)]
+#Siboor BOM Voron Trident AWD
+resistance: 0.9
+inductance: 0.0016
+holding_torque: 0.6
+max_current: 2.5
 steps_per_revolution: 200
 
 [motor_constants wantai-42byghw811]


### PR DESCRIPTION
Adding Siboor 14sth20-1004a and 42sth48-2504(s45). (Steppers used in Siboors AWD Trident kit)

Moving one 42sth from between 35sth behind.