### PR TITLE
Update for commonly use Neptune 4 steppers.

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -901,11 +901,36 @@ holding_torque: 0.65
 max_current: 2
 steps_per_revolution: 200
 
-[motor_constants bj42d22-53v04] 
+[motor_constants bj42d22-53v04]             
+# neptune 4 series 1.2A version of the x/y stepper motor
 resistance: 2.1
 inductance: 0.0046
 holding_torque: 0.4
 max_current: 1.20
+steps_per_revolution: 200
+
+[motor_constants bj42d15-26v77]
+# neptune 4 series 0.8A version of the x/y stepper motor
+resistance: 6
+inductance: 0.0088
+holding_torque: 0.28
+max_current: 0.8
+steps_per_revolution: 200
+
+[motor_constants bj42d15-26v78]
+# neptune 4 series 0.8A version of the z axis stepper motor
+resistance: 6.5
+inductance: 0.00826
+holding_torque: 0.28                       
+max_current:    0.8
+steps_per_revolution: 200
+
+[motor_constants bj36d12-04v05]
+# neptune 4 series extruder motor
+resistance: 2.0
+inductance: 0.0014
+holding_torque: 0.09
+max_current: 1.0
 steps_per_revolution: 200
 
 [motor_constants bjd42d22-53v02]

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -901,6 +901,13 @@ holding_torque: 0.65
 max_current: 2
 steps_per_revolution: 200
 
+[motor_constants bj42d22-53v04] 
+resistance: 2.1
+inductance: 0.0046
+holding_torque: 0.4
+max_current: 1.20
+steps_per_revolution: 200
+
 [motor_constants bjd42d22-53v02]
 #Flashforge adventurer 5m/pro motors
 resistance: 2.10


### PR DESCRIPTION
- The bj42d22-53v04 is the 1.2A stepper commonly used in the Neptune 4 X/Y steppers.
- The bj42d15-26v77 is the 0.8A stepper commonly used in original Neptune 4 X/Y steppers. Please read the Elegoo firmware docs to find out which one you have.
- The bj42d15-26v78 is commonly used in the Neptune 4 Z steppers.
- The bj36d12-04v05 is commonly used in the Neptune 4 extruder stepper.