### PR TITLE
Move code ouf of the klippy:ready handler into a deferred callback.

### DIFF
--- a/autotune_tmc.py
+++ b/autotune_tmc.py
@@ -149,7 +149,13 @@ class AutotuneTMC:
             self.tuning_goal = TuningGoal.SILENT if self.auto_silent else TuningGoal.PERFORMANCE
         self.motor_object = self.printer.lookup_object(self.motor_name)
         #self.tune_driver()
+
     def handle_ready(self):
+      # klippy:ready handlers are limited in what they may do. Communicating with a MCU
+      # will pause the reactor and is thus forbidden. That code has to run outside of the event handler.
+      self.printer.reactor.register_callback(self._handle_ready_deferred)
+
+    def _handle_ready_deferred(self, eventtime):
         if self.tmc_init_registers is not None:
             self.tmc_init_registers(print_time=print_time)
         try:


### PR DESCRIPTION
Currently the klippy:ready event handler breaks the rules by pausing the reactor. This happens when using mcu_tmc.

As a result of that, the printer will appear ready to Moonraker before it really, which then can lead to Moonraker sending commands to a not-ready Klipper. A scenario where this happens (moonraker-timelapse) and details can be found in the discussion of https://github.com/Klipper3d/klipper/pull/6631.

This fix moves the problematic code out of the event handler by registering a callback which then runs the tuning.