### PR TITLE
Add omc-17hs16-2004s1 details to motor database

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -404,6 +404,13 @@ holding_torque: 0.65
 max_current: 2.1
 steps_per_revolution: 200
 
+[motor_constants omc-17hs16-2004s1]
+resistance: 1.1
+inductance: 0.0026
+holding_torque: 0.45
+max_current: 2
+steps_per_revolution: 200
+
 [motor_constants omc-17hs19-2004s1]
 resistance: 1.4
 inductance: 0.003


### PR DESCRIPTION
This motor is used on my Reprap Snappy, details added according to the spec sheet that came with it.