### PR TITLE
Update motor_database.cfg

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -61,6 +61,13 @@ holding_torque: 0.06
 max_current: 0.35
 steps_per_revolution: 200
 
+[motor_constants fysetc-g36hsy4405-6d-1200]
+resistance: 2.4
+inductance:  0.0017
+holding_torque: 0.11
+max_current: 1.0
+steps_per_revolution: 200
+
 ## NEMA 17
 
 [motor_constants ldo-42sth40-1684cl350et]


### PR DESCRIPTION
Added Fysetc Nema 14 36mm pancake motor 10 teeth model G36HSY4405-6D-1200. 

Relevant specs [here](https://github.com/FYSETC/FYSETC-MOTORS/blob/main/G36HSY4405-6D-1200/G36HSY4405-6D-1200.pdf)

There is also a 1200**A** model with 8 teeth with the same specs ([here](https://github.com/FYSETC/FYSETC-MOTORS/blob/main/G36HSY4405-6D-1200A/G36HSY4405-6D-1200A.pdf))