### PR TITLE
added k1c/k1se's motors cfg

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -901,6 +901,22 @@ holding_torque: 0.65
 max_current: 2
 steps_per_revolution: 200
 
+[motor_constants bj42d29-30v00]
+#Creality K1c&K1Se A/B motors
+resistance: 1.35
+inductance: 0.003
+holding_torque: 0.44
+max_current: 1.8
+steps_per_revolution: 200
+
+[motor_constants bj42d22-44v26]
+#Creality K1c&K1Se Z motors
+resistance: 3.6
+inductance: 0.008
+holding_torque: 0.4
+max_current: 1
+steps_per_revolution: 200
+
 [motor_constants bjd42d22-53v02]
 #Flashforge adventurer 5m/pro motors
 resistance: 2.10


### PR DESCRIPTION
I asked keli motors via email to give me the parameters for these two motors

The difference between the k1c and the k1se is the sealing of the box and the presence or absence of a camera, the motor parameters remain unchanged.
I provided evidence of my motor model number and keli motors replying to the email

[BJ42D22-44V26 drawing.pdf](https://github.com/user-attachments/files/17893195/BJ42D22-44V26.drawing.pdf)
[BJ42D29-30V09 drawing.pdf](https://github.com/user-attachments/files/17893196/BJ42D29-30V09.drawing.pdf)
![2024112420333](https://github.com/user-attachments/assets/5be6eb5f-0a3f-4c02-9464-9609434ac565)
![20241124201333](https://github.com/user-attachments/assets/e01aacaa-a705-4fc9-84ac-edca59102a9b)
![2024-11-24 200017](https://github.com/user-attachments/assets/d7d9de99-05ab-45a4-8dd9-89a48db68d06)
