### PR TITLE
Add Support for Oukeda OK35STH52-1504A

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ function check_download {
 
     if [ ! -d "${AUTOTUNETMC_PATH}" ]; then
         echo "[DOWNLOAD] Downloading Autotune TMC repository..."
-        if git -C $autotunedirname clone https://github.com/andrewmcgr/klipper_tmc_autotune.git $autotunebasename; then
+        if git -C $autotunedirname clone https://github.com/GravitySandwichh/klipper_tmc_autotune.git $autotunebasename; then
             chmod +x ${AUTOTUNETMC_PATH}/install.sh
             printf "[DOWNLOAD] Download complete!\n\n"
         else

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -870,6 +870,20 @@ holding_torque: 0.40
 max_current: 1.70
 steps_per_revolution: 200
 
+### Oukeda Motors ###
+
+## NEMA14
+
+[motor_constants oukeda-ok35sth52-1504a]
+#formbot kit Voron 0.1
+resistance: 2.80
+inductance: 0.0038
+holding_torque: 0.40
+max_current: 1.5
+steps_per_revolution: 200
+
+## NEMA17
+
 [motor_constants oukeda-ok42hc40-204a306n84]
 #formbot kit trident Z
 resistance: 1.10

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -884,6 +884,14 @@ steps_per_revolution: 200
 
 ## NEMA17
 
+[motor_constants oukeda-ok42sth34-044e]
+#formbot kit Voron 0.1
+resistance: 2.80
+inductance: 0.0038
+holding_torque: 0.40
+max_current: 1.5
+steps_per_revolution: 200
+
 [motor_constants oukeda-ok42hc40-204a306n84]
 #formbot kit trident Z
 resistance: 1.10


### PR DESCRIPTION
Added Oukeda OK35STH52-1504A commonly used in formbot kits from 2021-2022.