### PR TITLE
Add Bondtech LGX Lite (V2 and Pro) motors

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -206,6 +206,22 @@ holding_torque: 0.23
 max_current: 1.4
 steps_per_revolution: 200
 
+### Bondtech ###
+[motor_constants bondtech-acc01stm41280]
+# Bondtech LGX Lite V2 motor (22mm) https://www.bondtech.se/downloads/TDS/Bondtech_ACC01STM41280.pdf
+resistance: 2.37
+inductance: 0.0012
+holding_torque: 0.0883
+max_current: 1
+steps_per_revolution: 200
+
+[motor_constants bondtech-36h020h-1004a-001]
+# Bondtech LGX Lite Pro motor (36mm) https://www.bondtech.se/downloads/TDS/Bondtech-13013A-classH-36H020H-1004A-001.pdf?srsltid=AfmBOoo4qqMmfeIV0JUmBfohUlgZpRCy8FLHqFx-9bZLsHoDCtXYTudq
+resistance: 2.37
+inductance: 0.0012
+holding_torque: 0.0883
+max_current: 1
+steps_per_revolution: 200
 
 ### Moons Motors ###
 


### PR DESCRIPTION
This is my first time adding motors to the DB, if you're able to, please check my work. Bondtech spec sheets listed below.

Lite V2 Motor: https://www.bondtech.se/downloads/TDS/Bondtech_ACC01STM41280.pdf

Lite Pro Motor: https://www.bondtech.se/downloads/TDS/Bondtech-13013A-classH-36H020H-1004A-001.pdf?srsltid=AfmBOoo4qqMmfeIV0JUmBfohUlgZpRCy8FLHqFx-9bZLsHoDCtXYTudq