### PR TITLE
Add omc-17he24-2104s to motor_database.cfg

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -353,6 +353,12 @@ max_current: 0.40
 steps_per_revolution: 200
 
 ## NEMA 17
+[motor_constants omc-17he24-2104s]
+resistance: 1.7
+inductance: 0.0031
+holding_torque: 0.60
+max_current: 2.1
+steps_per_revolution: 200
 
 [motor_constants omc-17he19-2004s]
 resistance: 1.3
@@ -367,7 +373,6 @@ inductance: 0.004
 holding_torque: 0.42
 max_current: 1.50
 steps_per_revolution: 200
-
 
 [motor_constants omc-17hs15-1504s]
 resistance: 2.30


### PR DESCRIPTION
Add omc-17he24-2104s with spec from https://www.omc-stepperonline.com/fr/moteur-pas-a-pas-nema-17-serie-e-1-8deg-60ncm-84-97oz-in-2-1a-42x42x60mm-4-fils-17he24-2104s 