### PR TITLE
Add custom TH3D Studio NEMA 17 pancake stepper motor

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -71,6 +71,15 @@ holding_torque: 0.45
 max_current: 2.0
 steps_per_revolution: 200
 
+[motor_constants th3d-nema17-pancake]
+# Custom TH3D Studio pancake motor
+# https://www.th3dstudio.com/product/1a-pancake-stepper-motor-nema-17-22-6mm/
+resistance: 4.1
+inductance: 0.0041
+holding_torque: 0.13
+max_current: 1.0
+steps_per_revolution: 200
+
 [motor_constants ldo-42sth40-1684l300e]
 #Trident Z motor kit from LDO
 resistance: 1.65


### PR DESCRIPTION
This commit adds the custom stepper motor built for TH3D.

The original manufacturer is unfortunately unknown.
No markings are present on the motor and TH3D is secret about their supplier/manufacturer.

Given the popularity of TH3D it makes nevertheless sense to add the motor, as many extruders sold by TH3D ship with this motor.