### PR TITLE
Add Creality Ender 3 Max stepper motors

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -709,6 +709,25 @@ holding_torque: 0.76
 max_current: 2.00
 steps_per_revolution: 200
 
+[motor_constants BJ42D15-26V]
+# https://gist.github.com/knoopx/e6c40a009e796203b93a75a3ed6a5ab8?permalink_comment_id=5399665#gistcomment-5399665
+# Applies to the following motors:
+# BJ42D15-26V09
+# BJ42D15-26V12
+resistance: 6.0
+inductance: 0.0088
+holding_torque: 0.28
+max_current: 0.84
+steps_per_revolution: 200
+
+[motor_constants BJ42D22-23V01]
+# https://gist.github.com/knoopx/e6c40a009e796203b93a75a3ed6a5ab8?permalink_comment_id=5399665#gistcomment-5399665
+resistance: 2.8
+inductance: 0.0069
+holding_torque: 0.37
+max_current: 1.0
+steps_per_revolution: 200
+
 [motor_constants BJ42D09-20V02]
 #Creality Sprite Pro https://user-images.githubusercontent.com/862951/235050029-79124b76-81d3-4f77-9501-6404f7c38336.png
 resistance: 1.75


### PR DESCRIPTION
Add 3 different motor types found on the Creality Ender 3 Max.

The specs were provided directly from the manufacturer.
Source: https://gist.github.com/knoopx/e6c40a009e796203b93a75a3ed6a5ab8?permalink_comment_id=5399665#gistcomment-5399665