### PR TITLE
Added JKong Motor JK42HS48-1684

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -957,9 +957,9 @@ steps_per_revolution: 200
 
 [motor_constants jkong-Jjk42hs48-1684]
 resistance: 1.65
-inductance: 0.0028 
+inductance: 0.0028
 holding_torque: 0.44
-max_current: 1.65
+max_current: 1.68
 steps_per_revolution: 200
 
 [motor_constants biqu-35BYGF0713-A-10HZT]

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -955,6 +955,13 @@ holding_torque: 0.4
 max_current: 1.7
 steps_per_revolution: 200
 
+[motor_constants jkong-Jjk42hs48-1684]
+resistance: 1.65
+inductance: 0.0028 
+holding_torque: 0.44
+max_current: 1.65
+steps_per_revolution: 200
+
 [motor_constants biqu-35BYGF0713-A-10HZT]
 resistance: 2.3
 inductance: 0.0020 

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -955,7 +955,7 @@ holding_torque: 0.4
 max_current: 1.7
 steps_per_revolution: 200
 
-[motor_constants jkong-Jjk42hs48-1684]
+[motor_constants jkong-jk42hs48-1684]
 resistance: 1.65
 inductance: 0.0028
 holding_torque: 0.44


### PR DESCRIPTION
Brand: JKong Motor
Model: JK42HS48-1684
resistance: 1.65
inductance: 0.0028
holding_torque: 0.44
max_current: 1.68
steps_per_revolution: 200

https://www.jkongmotor.com/Product/JKM-1-8Deg-Nema-17-Stepper-Motor.html