### PR TITLE
Add oukeda-ok42hc40-1684a-xh to motor_database.cfg

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -878,6 +878,14 @@ holding_torque: 0.45
 max_current: 2.00
 steps_per_revolution: 200
 
+[motor_constants oukeda-ok42hc40-1684a-xh]
+#formbot kit micron plus Z
+resistance: 1.95
+inductance: 0.0044
+holding_torque: 0.45
+max_current: 1.68
+steps_per_revolution: 200
+
 [motor_constants oukeda-17hs4401]
 resistance: 1.5
 inductance: 0.0028


### PR DESCRIPTION
From the spec sheet that came with my micron kit (it was the first batch, they might have changed the motors since then). The label on the motor that came with my kit is different from one on the spec sheet though.

<img width="1239" alt="image" src="https://github.com/user-attachments/assets/995d8f32-3bf2-4837-9ac9-156ac739dc5e" />
<img width="1239" alt="image" src="https://github.com/user-attachments/assets/f3bd830c-1f3c-4679-89cd-28c56b5d1065" />

