### PR TITLE
Adds config for STEPPERONLINE 14HS11-1004S

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -327,6 +327,13 @@ holding_torque: 0.4
 max_current: 1.5
 steps_per_revolution: 200
 
+[motor_constants omc-14hs11-1004s]
+resistance: 3.5
+inductance: 0.0035
+holding_torque: 0.125
+max_current: 1.0
+steps_per_revolution: 200
+
 [motor_constants omc-14hr07-1004vrn]
 resistance: 3.9
 inductance: 0.002


### PR DESCRIPTION
From the datasheet.

[Nema 14 Bipolar 1.8deg 12.5Ncm(17.7oz.in) 1.0A 35x35x28mm 4 Wires](https://www.omc-stepperonline.com/nema-14-bipolar-1-8deg-12-5ncm-17-7oz-in-1a-3-5v-35x35x28mm-4-wires-14hs11-1004s)

<img width="1124" alt="Screenshot 2025-04-23 at 8 21 42 PM" src="https://github.com/user-attachments/assets/9260328a-28b9-4ac0-92c2-d496db7d8f5f" />
