### PR TITLE
Formbot Trident kit motor updates

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -271,6 +271,14 @@ holding_torque: 0.054
 max_current: 0.65
 steps_per_revolution: 200
 
+# formbot trident kit z motors
+[motor_constants moons-le172s-t0804-300-cn-01-200]
+resistance: 1.04
+inductance: 0.0025
+holding_torque: 0.48
+max_current: 2.00
+steps_per_revolution: 200
+
 [motor_constants moons-ms17hd6p420I-04]
 resistance: 1.3
 inductance: 0.0027


### PR DESCRIPTION
Formbot updated their motors for the Trident kit. XY is using `moons-ms17hd6p420I-04` which is already present in the database. z is using moons-le172s-t0804-300-cn-01-200. The datasheet for the motors is at https://github.com/FORMBOT/Voron-Trident/tree/main/Motor%20SPEC but doesn't include holding_torque / static moment. I've contacted Formbot about it and they talked with Moons directly and Moons stated it is `0.48`. I've been running this for a couple of days now and all seems well. :+1: 