### PR TITLE
cleanup: Remove unused tmc_init_register property

### DIFF
--- a/autotune_tmc.py
+++ b/autotune_tmc.py
@@ -116,7 +116,6 @@ class AutotuneTMC:
         self.auto_silent = False # Auto silent off by default
         self.tmc_object=None # look this up at connect time
         self.tmc_cmdhelper=None # Ditto
-        self.tmc_init_registers=None # Ditto
         self.run_current = 0.0
         self.fclk = None
         self.motor_object = None
@@ -167,8 +166,6 @@ class AutotuneTMC:
       self.printer.reactor.register_callback(self._handle_ready_deferred)
 
     def _handle_ready_deferred(self, eventtime):
-        if self.tmc_init_registers is not None:
-            self.tmc_init_registers(print_time=print_time)
         try:
             self.fclk = self.tmc_object.mcu_tmc.get_tmc_frequency()
         except AttributeError:


### PR DESCRIPTION
Remove a property that is never set and refers to an undefined variable

Closes: #249
