### PR TITLE
Add Qidi Plus 4 X/Y motors to database

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -383,7 +383,7 @@ holding_torque: 0.40
 max_current: 1.50
 steps_per_revolution: 200
 
-[motor_constants omc-14hs20-1504s-c19] 
+[motor_constants omc-14hs20-1504s-c19]
 resistance: 2.0
 inductance: 0.0028
 holding_torque: 0.4
@@ -837,6 +837,14 @@ holding_torque: 0.09
 max_current: 1.0
 steps_per_revolution: 200
 
+[motor_constants qidi-BJ42D29-28V17]
+# used for X/Y-axis on QIDI PLUS 4
+resistance: 1.4
+inductance: 0.0026
+holding_torque: 0.41
+max_current: 1.5
+steps_per_revolution: 200
+
 ### Creality motors ###
 
 [motor_constants creality-42-34]
@@ -1272,7 +1280,7 @@ holding_torque: 0.18
 max_current: 1.0
 steps_per_revolution: 200
 
-[motor_constants hanpose-17HS6401S-0.9] 
+[motor_constants hanpose-17HS6401S-0.9]
 # 42ВYGН60Р170
 # https://www.zonemaker.com/product/190/
 # https://www.s3d.design/product-page/17hs6401s-0-9-degree-nema17-stepper-motor-hybrid-1-8a-70n-cm-60mm


### PR DESCRIPTION
I'm still trying to get the information about the other motors for the Plus 4, but in the meantime this is the one used for X and Y.

[BJ42D29-28V17 drawing.pdf](https://github.com/user-attachments/files/21139075/BJ42D29-28V17.drawing.pdf)
