### PR TITLE
Add ELEGOO Centauri Carbon steppers

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -926,6 +926,30 @@ holding_torque: 0.28
 max_current: 0.84
 steps_per_revolution: 200
 
+[motor_constants kelimotor-bj42d41-14v19]
+# ELEGOO Centauri Carbon A/B
+resistance: 1.1
+inductance: 0.0028
+holding_torque: 0.650
+max_current: 2.0
+steps_per_revolution: 200
+
+[motor_constants kelimotor-bj42d22-25v04]
+# ELEGOO Centauri Carbon Z
+resistance: 2.9
+inductance: 0.0060
+holding_torque: 0.400
+max_current: 1.2
+steps_per_revolution: 200
+
+[motor_constants kelimotor-bjy36d13-04v28]
+# ELEGOO Centauri Carbon E
+resistance: 2.0
+inductance: 0.0012
+holding_torque: 0.100
+max_current: 1.2
+steps_per_revolution: 200
+
 [motor_constants bondtech-42H025H-0704A-005]
 # Bondtech LGX https://www.bondtech.se/downloads/TDS/Bondtech-LGX-Motor-42H025H-0704-002.pdf
 resistance: 4.4


### PR DESCRIPTION
The Centauri Carbon uses three types of steppers from KELI steppers.

- A/B: https://s3.devminer.xyz/archive/BJ42D41-14V19%20drawing.pdf
- Z: https://s3.devminer.xyz/archive/BJ42D22-25V04%20drawing.pdf
- Extruder: https://s3.devminer.xyz/archive/BJY36D12-04V28%20drawing.pdf

The datasheets aren't available on KELI motors' website, but support gives them to the people who ask. I've mirrored them to my S3 bucket, for archival.