### PR TITLE
Adding support for moons CSE14HRA2L410A

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -296,6 +296,13 @@ holding_torque: 0.1
 max_current: 1.0
 steps_per_revolution: 200
 
+[motor_constants moons-cse14hra2l410a]
+resistance: 3.6
+inductance: 0.0038
+holding_torque: 0.19
+max_current: 1.0
+steps_per_revolution: 200
+
 ## NEMA 17
 
 [motor_constants moons-ms17hdbp4200]


### PR DESCRIPTION
Nema 14 stepper with 5mm shaft sold by formbot: https://www.formbot3d.com/products/moons-motor-for-marathon?VariantsId=11085

Datasheet isn't anywhere that I could find, but formbot support provided it on request.

[马拉松MOONS' NEMA14.pdf](https://github.com/user-attachments/files/21673812/MOONS.NEMA14.pdf)
