### PR TITLE
motor_database: Add Leadshine/Leisai 42CM08

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -1503,9 +1503,22 @@ holding_torque: 0.40
 max_current: 0.9
 steps_per_revolution: 200
 
+### China Leadshine Technology Co., Ltd Motors (Leisai, Leadshine) ##
+
+## NEMA17 ##
+
 [motor_constants leisai-42cm06d]
+# Motor Length 47mm
 resistance: 0.9
 inductance: 0.0016
 holding_torque: 0.6
+max_current: 2.5
+steps_per_revolution: 200
+
+[motor_constants leadshine-42cm08]
+# Motor Length 60mm
+resistance: 1.0
+inductance: 0.0024
+holding_torque: 0.8
 max_current: 2.5
 steps_per_revolution: 200


### PR DESCRIPTION
Add motor_constants entry for the Leadshine 42CM08 NEMA17 L=60mm motor with holding torque of 80Ncm (.8Nm), phase resistance of 1.0 ohms, phase inductance of 2.4mH.

While at it, also add a description for Leadshine/Leisai, clarifying that they're the same company (though, the new name, from year 2020 onwards seems to be Leadshine).