### PR TITLE
Add function to exclude specific files from Klipper git tracking

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -70,6 +70,15 @@ function link_extension {
     ln -srfn "${AUTOTUNETMC_PATH}/motor_database.cfg" "${KLIPPER_PLUGINS_PATH}/motor_database.cfg"
 }
 
+function add_to_exclude {
+    echo "[INSTALL] Adding files to Klipper git exclude..."
+    if [ -d "${KLIPPER_PATH}/.git" ]; then
+        grep -qxF "klippy/extras/save_state.py" "${KLIPPER_PATH}/.git/info/exclude" || echo "klippy/extras/save_state.py" >> "${KLIPPER_PATH}/.git/info/exclude"
+        grep -qxF "klippy/extras/motor_database.cfg" "${KLIPPER_PATH}/.git/info/exclude" || echo "klippy/extras/motor_database.cfg" >> "${KLIPPER_PATH}/.git/info/exclude"
+        grep -qxF "klippy/extras/autotune_tmc.py" "${KLIPPER_PATH}/.git/info/exclude" || echo "klippy/extras/autotune_tmc.py" >> "${KLIPPER_PATH}/.git/info/exclude"
+    fi
+}
+
 function restart_klipper {
     echo "[POST-INSTALL] Restarting Klipper..."
     sudo systemctl restart klipper
@@ -85,4 +94,5 @@ printf "======================================\n\n"
 preflight_checks
 check_download
 link_extension
+add_to_exclude
 restart_klipper


### PR DESCRIPTION
This PR updates the install.sh script to automatically add the symlinked extension files to the Klipper repository's exclude file.

When this extension is installed, it symlinks files into the Klipper extras (or plugins) directory. This often causes the Klipper repository to show these files as untracked changes, which can be confusing for users.

By adding these paths to exclude, we tell git to ignore them locally in the Klipper repo without needing to modify Klipper's own .gitignore.

Changes:

Added an add_to_exclude function that appends the following paths to ${KLIPPER_PATH}/.git/info/exclude:
klippy/extras/save_state.py
klippy/extras/motor_database.cfg
autotune_tmc.py

The script checks for existing entries before appending to prevent duplicates.
Integrated the call into the main installation flow.