### PR TITLE
Use absolute import for tmc module

### DIFF
--- a/autotune_tmc.py
+++ b/autotune_tmc.py
@@ -1,7 +1,11 @@
 import math, logging, os
 from enum import Enum
 from inspect import signature
-from . import tmc
+
+try:
+    from klippy.extras import tmc # Kalico
+except ImportError:
+    from . import tmc # Klipper
 
 # Autotune config parameters
 TUNING_GOAL = 'auto'


### PR DESCRIPTION
## Summary
Changes `from . import tmc` to `from extras import tmc` to fix compatibility with Kalico.

## Problem
Kalico PR https://github.com/KalicoCrew/kalico/pull/786 changed how plugins are loaded and single-file plugins in `klippy/plugins/` are now loaded as `klippy.plugins.*` instead of `klippy.extras.*`. This breaks relative imports like `from . import tmc` which now incorrectly resolve to `klippy.plugins.tmc` instead of `klippy.extras.tmc`.