### PR TITLE
Update motor_database.cfg added "ldo-36sth20-1004ahg(xh)"

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -37,6 +37,13 @@ holding_torque: 0.10
 max_current: 1.0
 steps_per_revolution: 200
 
+[motor_constants ldo-36sth20-1004ahg-xh]
+resistance: 2.6
+inductance: 0.0018
+holding_torque: 0.095
+max_current: 1.0
+steps_per_revolution: 200
+
 [motor_constants ldo-35sth52-1504ah]
 resistance: 2.8
 inductance: 0.0038


### PR DESCRIPTION
 "ldo-36sth20-1004ahg(xh)"

```
Step angle: 1.8° ± 5%
Holding torque: 95 mN-m
Rated current/phase: 1.0 A
Phase resistance: 2.6 ohms
Inductance: 1.8 mH ± 20%
Frame size: Ø36 mm
Body length: 20 mm
Shaft diameter: Φ2.5 mm
Shaft length: 4 mm
Cut-out length: 16 mm
Number of wires: 4ss
Weight: 85 g
Insulation class: 180°C class H
Maximum operating temperature: 120 °C
Motor gear: 10 teeth
```

https://biqu.equipment/products/ldo-36sth20-1004ahgxh-motor-driver?srsltid=AfmBOor35TTLNE7ZOg7zwcf3uFc2meZlrSRnFaLTJ1UAftPQw4hjFSyK