### PR TITLE
feat: add Biqu Nebula extruder motor

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -1371,6 +1371,13 @@ holding_torque: 0.11
 max_current: 1.5
 steps_per_revolution: 200
 
+[motor_constants biqu-nebula-extruder]
+resistance: 2.40
+inductance: 0.0017
+holding_torque: 0.11
+max_current: 1.0
+steps_per_revolution: 200
+
 [motor_constants jkong-jk42hw20-10041-04a]
 resistance: 6.8
 inductance: 0.007


### PR DESCRIPTION
## Summary
- Adds `biqu-nebula-extruder` to the motor database with values from the [official datasheet](https://global.bttwiki.com/Nebula.html)

Note: the original issue had the inductance in mH instead of H (1.7 vs 0.0017) and used 0.65A instead of the datasheet's rated 1.0A.

Closes #310