### PR TITLE
merge identical kelimotor-bj42d15-24v entries

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -928,17 +928,6 @@ holding_torque: 0.76
 max_current: 2.00
 steps_per_revolution: 200
 
-[motor_constants BJ42D15-26V]
-# https://gist.github.com/knoopx/e6c40a009e796203b93a75a3ed6a5ab8?permalink_comment_id=5399665#gistcomment-5399665
-# Applies to the following motors:
-# BJ42D15-26V09
-# BJ42D15-26V12
-resistance: 6.0
-inductance: 0.0088
-holding_torque: 0.28
-max_current: 0.84
-steps_per_revolution: 200
-
 [motor_constants BJ42D22-23V01]
 # https://gist.github.com/knoopx/e6c40a009e796203b93a75a3ed6a5ab8?permalink_comment_id=5399665#gistcomment-5399665
 resistance: 2.8
@@ -955,8 +944,12 @@ holding_torque: 0.15
 max_current: 0.84
 steps_per_revolution: 200
 
-[motor_constants kelimotor-bj42d15-26v09]
+[motor_constants kelimotor-bj42d15-26v]
 # Found in some Ender3 - https://hssn.hs-ldz.pl/datasheet/BJ42D22-23V01.pdf
+# Applies to the following motors:
+# BJ42D15-26V09 https://gist.github.com/knoopx/e6c40a009e796203b93a75a3ed6a5ab8?permalink_comment_id=5399665#gistcomment-5399665
+# BJ42D15-26V12
+# BJ42D15-26V10 https://gist.github.com/knoopx/e6c40a009e796203b93a75a3ed6a5ab8?permalink_comment_id=5443111#gistcomment-5443111
 resistance: 6.0
 inductance: 0.0088
 holding_torque: 0.28


### PR DESCRIPTION
The following Kelimotor steppers have the same specs (as per their datasheets): 
bj42d15-26v09
bj42d15-26v10
bj42d15-26v12