### PR TITLE
feat: add motor aliasing with deprecation warnings

### DIFF
--- a/.github/scripts/motor_database_validator.py
+++ b/.github/scripts/motor_database_validator.py
@@ -3,6 +3,7 @@
 import argparse
 import logging
 import sys
+from collections import defaultdict
 from configparser import ConfigParser, Error
 from enum import IntEnum
 from pathlib import Path
@@ -24,41 +25,31 @@ MOTOR_PARAMS: dict[str, ValueType] = {
     "steps_per_revolution": ValueType.CUSTOM,
 }
 
+ALIAS_REQUIRED_PARAMS: set[str] = {"motor"}
+ALIAS_OPTIONAL_PARAMS: set[str] = {"deprecated"}
+ALIAS_ALL_PARAMS: set[str] = ALIAS_REQUIRED_PARAMS | ALIAS_OPTIONAL_PARAMS
 
-def validate():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-v", "--verbose", help="Verbose output", action="store_true")
-    parser.add_argument(
-        "database", help="Path to the motor constants database to validate"
-    )
-    args = parser.parse_args()
 
-    level: int = logging.WARNING
-    if args.verbose:
-        level = logging.INFO
-
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s [%(levelname)s] %(message)s",
-        handlers=[logging.StreamHandler()],
-    )
-
-    database = Path(args.database)
-    if not database.exists():
-        logger.error("Motor constants database %s not found!", args.database)
+def load_database(path: Path) -> ConfigParser:
+    if not path.exists():
+        logger.error("Motor constants database %s not found!", path)
         sys.exit(1)
 
     config = ConfigParser()
     try:
-        config.read(database)
+        config.read(path)
     except Error as e:
         logger.error("%s", str(e))
         sys.exit(1)
 
+    return config
+
+
+def validate_motors(config: ConfigParser, motor_sections: list[str]) -> bool:
     valid = True
     required_params = set(MOTOR_PARAMS.keys())
 
-    for motor_name in config.sections():
+    for motor_name in motor_sections:
         _, name, *_ = motor_name.split()
         logger.info("Verifying motor %s", name)
         motor_params = set(config.options(motor_name))
@@ -72,6 +63,8 @@ def validate():
                 )
 
         for param, kind in MOTOR_PARAMS.items():
+            if param not in motor_params:
+                continue
             match kind:
                 case ValueType.FLOAT:
                     try:
@@ -128,10 +121,156 @@ def validate():
                             raise RuntimeError(
                                 f"No custom validation rule defined form parameter {param}"
                             )
-    if not valid:
-        logger.error("Encountered validation errors in database file %s", database)
-        sys.exit(1)
+    return valid
+
+
+def validate_aliases(
+    config: ConfigParser,
+    motor_sections: list[str],
+    alias_sections: list[str],
+) -> bool:
+    valid = True
+    motor_names = {s.split()[-1] for s in motor_sections}
+    alias_names: set[str] = set()
+
+    for alias_section in alias_sections:
+        _, name, *_ = alias_section.split()
+        logger.info("Verifying alias %s", name)
+        alias_params = set(config.options(alias_section))
+
+        if missing := ALIAS_REQUIRED_PARAMS - alias_params:
+            valid = False
+            for param in sorted(missing):
+                logger.error(
+                    "Required parameter %s is missing from alias %s",
+                    param,
+                    name,
+                )
+
+        if unexpected := alias_params - ALIAS_ALL_PARAMS:
+            valid = False
+            for param in sorted(unexpected):
+                logger.error(
+                    "Unexpected parameter %s in alias %s",
+                    param,
+                    name,
+                )
+
+        if name in motor_names:
+            logger.error(
+                "Alias %s conflicts with an existing motor_constants definition",
+                name,
+            )
+            valid = False
+
+        if name in alias_names:
+            logger.error("Duplicate alias definition for %s", name)
+            valid = False
+        alias_names.add(name)
+
+        if "motor" in alias_params:
+            target = config.get(alias_section, "motor")
+            if target not in motor_names:
+                if target in alias_names or any(
+                    s.split()[-1] == target for s in alias_sections
+                ):
+                    logger.error(
+                        "Alias %s targets another alias '%s', alias chains are not allowed",
+                        name,
+                        target,
+                    )
+                else:
+                    logger.error(
+                        "Alias %s references unknown motor '%s'",
+                        name,
+                        target,
+                    )
+                valid = False
+
+        if "deprecated" in alias_params:
+            value = config.get(alias_section, "deprecated").lower()
+            if value not in ("true", "false", "yes", "no", "1", "0"):
+                logger.error(
+                    "Invalid boolean value '%s' for deprecated in alias %s",
+                    value,
+                    name,
+                )
+                valid = False
+
+    return valid
+
+
+def check_duplicates(config: ConfigParser, motor_sections: list[str]) -> None:
+    specs: dict[tuple, list[str]] = defaultdict(list)
+    spec_keys = (
+        "resistance",
+        "inductance",
+        "holding_torque",
+        "max_current",
+        "steps_per_revolution",
+    )
+
+    for motor_name in motor_sections:
+        name = motor_name.split()[-1]
+        try:
+            values = tuple(float(config.get(motor_name, k)) for k in spec_keys)
+        except (ValueError, Exception):
+            continue
+        specs[values].append(name)
+
+    found = False
+    for values, names in sorted(specs.items()):
+        if len(names) > 1:
+            found = True
+            spec_str = ", ".join("%s=%s" % (k, v) for k, v in zip(spec_keys, values))
+            logger.warning(
+                "Duplicate motor specs found: [%s] share identical values (%s)",
+                ", ".join(sorted(names)),
+                spec_str,
+            )
+
+    if not found:
+        logger.info("No duplicate motor specifications found")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="Verbose output", action="store_true")
+    parser.add_argument(
+        "--check-duplicates",
+        help="Check for duplicate motor specs (advisory, does not block)",
+        action="store_true",
+    )
+    parser.add_argument("database", help="Path to the motor constants database")
+    args = parser.parse_args()
+
+    level: int = logging.WARNING
+    if args.verbose:
+        level = logging.INFO
+
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[logging.StreamHandler()],
+    )
+
+    config = load_database(Path(args.database))
+
+    motor_sections = [s for s in config.sections() if s.startswith("motor_constants ")]
+    alias_sections = [s for s in config.sections() if s.startswith("motor_alias ")]
+
+    if args.check_duplicates:
+        check_duplicates(config, motor_sections)
+    else:
+        valid = validate_motors(config, motor_sections)
+        valid = validate_aliases(config, motor_sections, alias_sections) and valid
+        if not valid:
+            logger.error(
+                "Encountered validation errors in database file %s",
+                args.database,
+            )
+            sys.exit(1)
 
 
 if __name__ == "__main__":
-    validate()
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,3 +39,6 @@ jobs:
 
     - name: Validate Motor Database
       run: python3 ${{github.workspace}}/.github/scripts/motor_database_validator.py -v ${{github.workspace}}/motor_database.cfg
+
+    - name: Check for Duplicate Motor Specs
+      run: python3 ${{github.workspace}}/.github/scripts/motor_database_validator.py -v --check-duplicates ${{github.workspace}}/motor_database.cfg

--- a/autotune_tmc.py
+++ b/autotune_tmc.py
@@ -9,6 +9,8 @@ try:
 except ImportError:
     from . import tmc  # Klipper
 
+from . import motor_constants
+
 # Autotune config parameters
 TUNING_GOAL = "auto"
 EXTRA_HYSTERESIS = 0
@@ -96,8 +98,11 @@ class AutotuneTMC:
             motor_db = pconfig.read_config(filename)
         except Exception:
             raise config.error("Cannot load config '%s'" % (filename,))
-        for motor in motor_db.get_prefix_sections(""):
+        for motor in motor_db.get_prefix_sections("motor_constants"):
             self.printer.load_object(motor_db, motor.get_name())
+        for alias in motor_db.get_prefix_sections("motor_alias"):
+            alias_obj = motor_constants.MotorAlias(alias)
+            self.printer.objects[alias.get_name()] = alias_obj
 
         # Now find our stepper and driver in the running Klipper config
         self.name = config.get_name().split(None, 1)[-1]
@@ -182,6 +187,10 @@ class AutotuneTMC:
         )
 
     def handle_connect(self):
+        # Register aliases now that all user motor_constants are loaded
+        for name, obj in list(self.printer.objects.items()):
+            if isinstance(obj, motor_constants.MotorAlias):
+                obj.register(self.printer)
         self.tmc_object = self.printer.lookup_object(self.driver_name)
         # The cmdhelper itself isn't a member... but we can still get to it.
         self.tmc_cmdhelper = self.tmc_object.get_status.__self__
@@ -193,6 +202,19 @@ class AutotuneTMC:
                 "It is not part of the database, please define it in your config!"
                 % (self.motor_name)
             )
+        alias_obj = self.printer.lookup_object(
+            "motor_alias " + self.motor, default=None
+        )
+        if alias_obj is not None and alias_obj.deprecated:
+            alias_target = self.printer.lookup_object(
+                "motor_constants " + alias_obj.motor, default=None
+            )
+            if motor is alias_target:
+                pconfig = self.printer.lookup_object("configfile")
+                pconfig.runtime_warning(
+                    "Motor name '%s' is deprecated, please update your config "
+                    "to use '%s' instead." % (self.motor, alias_obj.motor)
+                )
         if self.tuning_goal == TuningGoal.AUTO:
             # Very small motors may not run in silent mode.
             self.auto_silent = (

--- a/motor_constants.py
+++ b/motor_constants.py
@@ -74,5 +74,30 @@ class MotorConstants:
         return hstrt - 1, hend + 3
 
 
+class MotorAlias:
+    def __init__(self, config):
+        self.name: str = config.get_name().split()[-1]
+        self.motor: str = config.get("motor")
+        self.deprecated: bool = config.getboolean("deprecated", default=False)
+
+    def register(self, printer) -> None:
+        target_name: str = "motor_constants " + self.motor
+        target = printer.lookup_object(target_name, default=None)
+        if target is None:
+            raise printer.config_error(
+                "Motor alias '%s' references unknown motor '%s'"
+                % (self.name, self.motor)
+            )
+        if not isinstance(target, MotorConstants):
+            raise printer.config_error(
+                "Motor alias '%s' targets '%s' which is not a motor definition"
+                % (self.name, self.motor)
+            )
+        alias_key = "motor_constants " + self.name
+        existing = printer.objects.get(alias_key)
+        if existing is None or isinstance(existing, MotorAlias):
+            printer.objects[alias_key] = target
+
+
 def load_config_prefix(config):
     return MotorConstants(config)

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -99,13 +99,10 @@ holding_torque: 0.45
 max_current: 1.68
 steps_per_revolution: 200
 
-[motor_constants ldo-42sth40-1684l300e]
-# Trident Z motor kit from LDO
-resistance: 1.65
-inductance: 0.0041
-holding_torque: 0.45
-max_current: 1.68
-steps_per_revolution: 200
+[motor_alias ldo-42sth40-1684l300e]
+# Same motor as ldo-42sth40-1684cl350et, different leadscrew length
+motor: ldo-42sth40-1684cl350et
+deprecated: false
 
 [motor_constants ldo-42sth40-1684ac]
 resistance: 1.65
@@ -143,12 +140,10 @@ holding_torque: 0.55
 max_current: 2.5
 steps_per_revolution: 200
 
-[motor_constants ldo-42sth48-2504ah]
-resistance: 1.2
-inductance: 0.0015
-holding_torque: 0.55
-max_current: 2.5
-steps_per_revolution: 200
+[motor_alias ldo-42sth48-2504ah]
+# Same motor as ldo-42sth48-2504ac, AH = high-temp variant of AC = standard
+motor: ldo-42sth48-2504ac
+deprecated: false
 
 [motor_constants ldo-42sth48-2504macf]
 resistance: 1.2
@@ -369,19 +364,32 @@ holding_torque: 0.48
 max_current: 2.00
 steps_per_revolution: 200
 
-[motor_constants moons-ms17hd6p420I-04]
+[motor_constants moons-ms17hd6p420i]
 resistance: 1.3
 inductance: 0.0027
 holding_torque: 0.67
 max_current: 2.0
 steps_per_revolution: 200
 
-[motor_constants moons-ms17hd6p420I-05]
-resistance: 1.3
-inductance: 0.0027
-holding_torque: 0.67
-max_current: 2.0
-steps_per_revolution: 200
+[motor_alias moons-ms17hd6p420-04]
+motor: moons-ms17hd6p420i
+deprecated: false
+
+[motor_alias moons-ms17hd6p420I-04]
+# Legacy uppercase name, -04 variant
+# Remove after: 2027-03-25
+motor: moons-ms17hd6p420i
+deprecated: true
+
+[motor_alias moons-ms17hd6p420i-05]
+motor: moons-ms17hd6p420i
+deprecated: false
+
+[motor_alias moons-ms17hd6p420I-05]
+# Legacy uppercase name, -05 variant
+# Remove after: 2027-03-25
+motor: moons-ms17hd6p420i
+deprecated: true
 
 # Comes stock on many older Creality printers, e.g: Ender 3, V2, Max
 [motor_constants moons-c17hd2024n-01n]
@@ -411,12 +419,11 @@ steps_per_revolution: 200
 
 ## NEMA 14
 
-[motor_constants omc-14ms20-1504s]
-resistance: 2.80
-inductance: 0.0038
-holding_torque: 0.40
-max_current: 1.50
-steps_per_revolution: 200
+[motor_alias omc-14ms20-1504s]
+# Likely typo for omc-14hs20-1504s (MS vs HS)
+# Remove after: 2027-03-25
+motor: omc-14hs20-1504s
+deprecated: true
 
 [motor_constants omc-14hs20-1504s-c19]
 resistance: 2.0
@@ -621,12 +628,9 @@ steps_per_revolution: 200
 
 ## NEMA 14
 
-[motor_constants fysetc-g36hsy4405-6d-80a]
-resistance: 2.4
-inductance:  0.0017
-holding_torque: 0.11
-max_current: 1.0
-steps_per_revolution: 200
+[motor_alias fysetc-g36hsy4405-6d-80a]
+motor: fysetc-g36hsy4405-6d-1200
+deprecated: false
 
 [motor_constants fysetc-g36hsy4407-6d-1200a]
 resistance: 13
@@ -635,13 +639,9 @@ holding_torque: 0.12
 max_current: 0.5
 steps_per_revolution: 200
 
-[motor_constants fysetc-g36hsy4405-6d-30]
-# Alternative name: G36HSY4405-6D-60
-resistance: 2.4
-inductance:  0.0017
-holding_torque: 0.11
-max_current: 1.0
-steps_per_revolution: 200
+[motor_alias fysetc-g36hsy4405-6d-30]
+motor: fysetc-g36hsy4405-6d-1200
+deprecated: false
 
 [motor_constants fysetc-35hsh7402-24b-60a]
 resistance: 2.8
@@ -650,12 +650,9 @@ holding_torque: 0.42
 max_current: 1.5
 steps_per_revolution: 200
 
-[motor_constants fysetc-35hsh7402-24b-60b]
-resistance: 2.8
-inductance: 0.0055
-holding_torque: 0.42
-max_current: 1.5
-steps_per_revolution: 200
+[motor_alias fysetc-35hsh7402-24b-60b]
+motor: fysetc-35hsh7402-24b-60a
+deprecated: false
 
 [motor_constants fysetc-42hsc1433b-200n8]
 resistance: 8
@@ -794,13 +791,11 @@ holding_torque: 0.6
 max_current: 2.5
 steps_per_revolution: 200
 
-[motor_constants siboor-42sth28-0804a]
-# Siboor BOM Voron 0.2 Z integrated leadscrew stepper (metal version)
-resistance: 5.5
-inductance: 0.0066
-holding_torque: 0.26
-max_current: 1.0
-steps_per_revolution: 200
+[motor_alias siboor-42sth28-0804a]
+# Same motor as 42sth26-0804a with a different bottom cover (metal version)
+# Source: https://github.com/andrewmcgr/klipper_tmc_autotune/pull/140
+motor: siboor-42sth26-0804a
+deprecated: false
 
 [motor_constants wantai-42byghw811]
 # Wantai Stepper Motor 42BYGHW811 and 42BYGHW811-X11
@@ -856,13 +851,19 @@ steps_per_revolution: 400
 
 ### QIDI motors ###
 
-[motor_constants qidi-BJ42D29-28V07]
+[motor_constants qidi-bj42d29-28v07]
 # used for X/Y-axis on QIDI X MAX 3
 resistance: 1.4
 inductance: 0.0026
 holding_torque: 0.41
 max_current: 1.5
 steps_per_revolution: 200
+
+[motor_alias qidi-BJ42D29-28V07]
+# Legacy uppercase name
+# Remove after: 2027-03-25
+motor: qidi-bj42d29-28v07
+deprecated: true
 
 [motor_constants qidi-BJ42D29-22V08]
 # used for Z-Axis on QIDI X MAX 3
@@ -880,21 +881,25 @@ holding_torque: 0.09
 max_current: 1.0
 steps_per_revolution: 200
 
-[motor_constants qidi-BJ42D29-28V17]
-# used for X/Y-axis on QIDI PLUS 4
-resistance: 1.4
-inductance: 0.0026
-holding_torque: 0.41
-max_current: 1.5
-steps_per_revolution: 200
+[motor_alias qidi-bj42d29-28v17]
+# Same motor as bj42d29-28v07, used for X/Y-axis on QIDI PLUS 4
+motor: qidi-bj42d29-28v07
 
-[motor_constants qidi-BJ42D29-28V09]
-# used for X/Y-axis on QIDI Q1 Pro
-resistance: 1.4
-inductance: 0.0026
-holding_torque: 0.41
-max_current: 1.5
-steps_per_revolution: 200
+[motor_alias qidi-BJ42D29-28V17]
+# Legacy uppercase name
+# Remove after: 2027-03-25
+motor: qidi-bj42d29-28v07
+deprecated: true
+
+[motor_alias qidi-bj42d29-28v09]
+# Same motor as bj42d29-28v07, used for X/Y-axis on QIDI PLUS 4
+motor: qidi-bj42d29-28v07
+
+[motor_alias qidi-BJ42D29-28V09]
+# Legacy uppercase name
+# Remove after: 2027-03-25
+motor: qidi-bj42d29-28v07
+deprecated: true
 
 ### Creality motors ###
 
@@ -930,6 +935,7 @@ steps_per_revolution: 200
 
 [motor_alias BJ42D15-26V]
 # Legacy name, replaced by kelimotor-bj42d15-26v09
+# Remove after: 2027-03-25
 motor: kelimotor-bj42d15-26v09
 deprecated: true
 
@@ -999,13 +1005,17 @@ holding_torque: 0.16
 max_current: 0.7
 steps_per_revolution: 200
 
-[motor_constants bondtech-36H020H-1004A-001]
-# Bondtech LGX Lite v2 https://www.bondtech.se/downloads/TDS/Bondtech-13013A-classH-36H020H-1004A-001.pdf
-resistance: 2.37
-inductance: 0.0012
-holding_torque: 0.09
-max_current: 1.0
-steps_per_revolution: 200
+[motor_alias bondtech-36H020H-1004A-001]
+# Legacy uppercase name
+# Remove after: 2027-03-25
+motor: bondtech-acc01stm41280
+deprecated: true
+
+[motor_alias bondtech-36h020h-1004a-001]
+# Bondtech LGX Lite v2, same motor as acc01stm41280 (LGX Lite PRO)
+# https://www.bondtech.se/downloads/TDS/Bondtech-13013A-classH-36H020H-1004A-001.pdf
+motor: bondtech-acc01stm41280
+deprecated: false
 
 [motor_constants bondtech-acc01stm41280]
 # Bondtech LGX Lite PRO eXtruder: https://www.bondtech.se/downloads/TDS/Bondtech_ACC01STM41280.pdf
@@ -1252,13 +1262,11 @@ holding_torque: 0.21
 max_current: 1.0
 steps_per_revolution: 200
 
-[motor_constants bj42d41-14v06]
-# Creality K1&Max A/B motors
-resistance: 1.1
-inductance: 0.0028
-holding_torque: 0.65
-max_current: 2
-steps_per_revolution: 200
+[motor_alias bj42d41-14v06]
+# Legacy name without vendor prefix, Creality K1&Max A/B motors
+# Remove after: 2027-03-25
+motor: kelimotor-bj42d41-14v19
+deprecated: true
 
 [motor_constants bj42d29-30v00]
 #Creality K1c&K1Se A/B motors

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -928,16 +928,10 @@ holding_torque: 0.76
 max_current: 2.00
 steps_per_revolution: 200
 
-[motor_constants BJ42D15-26V]
-# https://gist.github.com/knoopx/e6c40a009e796203b93a75a3ed6a5ab8?permalink_comment_id=5399665#gistcomment-5399665
-# Applies to the following motors:
-# BJ42D15-26V09
-# BJ42D15-26V12
-resistance: 6.0
-inductance: 0.0088
-holding_torque: 0.28
-max_current: 0.84
-steps_per_revolution: 200
+[motor_alias BJ42D15-26V]
+# Legacy name, replaced by kelimotor-bj42d15-26v09
+motor: kelimotor-bj42d15-26v09
+deprecated: true
 
 [motor_constants BJ42D22-23V01]
 # https://gist.github.com/knoopx/e6c40a009e796203b93a75a3ed6a5ab8?permalink_comment_id=5399665#gistcomment-5399665
@@ -956,12 +950,22 @@ max_current: 0.84
 steps_per_revolution: 200
 
 [motor_constants kelimotor-bj42d15-26v09]
+# https://gist.github.com/knoopx/e6c40a009e796203b93a75a3ed6a5ab8?permalink_comment_id=5399665#gistcomment-5399665
 # Found in some Ender3 - https://hssn.hs-ldz.pl/datasheet/BJ42D22-23V01.pdf
+# Also applies to: BJ42D15-26V10, BJ42D15-26V12
 resistance: 6.0
 inductance: 0.0088
 holding_torque: 0.28
 max_current: 0.84
 steps_per_revolution: 200
+
+[motor_alias kelimotor-bj42d15-26v10]
+motor: kelimotor-bj42d15-26v09
+deprecated: false
+
+[motor_alias kelimotor-bj42d15-26v12]
+motor: kelimotor-bj42d15-26v09
+deprecated: false
 
 [motor_constants kelimotor-bj42d41-14v19]
 # ELEGOO Centauri Carbon A/B


### PR DESCRIPTION
## Summary

- Add `[motor_alias]` sections to `motor_database.cfg` that map alternate motor names to canonical `motor_constants` entries, with an optional `deprecated` flag
- Deprecated aliases surface warnings in Mainsail/Fluidd via Klipper's `runtime_warning` mechanism, prompting users to update their config
- Extend `motor_database_validator.py` with alias validation and advisory duplicate detection (`--check-duplicates`)
- Convert `BJ42D15-26V` / `kelimotor-bj42d15-26v09` duplicate entries as proof of concept (relates to #320)

## Motivation

PR #320 identified duplicate motor entries that should be consolidated, but removing old names would break existing user configs. This PR adds an aliasing mechanism that allows consolidating duplicates while preserving backward compatibility.

## Design

- `MotorAlias` class in `motor_constants.py` with separate `__init__` (config parsing) and `register()` (target resolution)
- Two-pass loading in `autotune_tmc.py`: all `motor_constants` first, then `motor_alias` sections
- User-defined `motor_constants` in `printer.cfg` take precedence over aliases
- Alias-to-alias chains are prevented (validated both at runtime and by CI)
- `deprecated` defaults to `false` — non-deprecated aliases are silent, deprecated ones warn

## Test plan

- [x] Verify `ruff check` and `ruff format --check` pass
- [x] Verify `motor_database_validator.py -v motor_database.cfg` passes
- [x] Verify `motor_database_validator.py -v --check-duplicates motor_database.cfg` reports duplicates without failing
- [x] Test with `motor: kelimotor-bj42d15-26v09` in config (canonical name, no warning)
- [x] Test with `motor: BJ42D15-26V` in config (deprecated alias, warning in UI)
- [x] Test with `motor: kelimotor-bj42d15-26v10` in config (non-deprecated alias, no warning)
- [x] Test with user-defined `[motor_constants BJ42D15-26V]` in printer.cfg (user definition wins)