### PR TITLE
Adding motor with normalized name.

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -1626,14 +1626,11 @@ steps_per_revolution: 200
 ### generic - for Voron 3D ###
 
 ## NEMA14 ##
-[motor_constants generic-6BYG1204-A-6QHT]
+[motor_alias generic-6BYG1204-A-6QHT]
 # For CR10 CR 10S Ender3 V2 VORON HGX LITE Extruder Dual Gear Extruder Hard Steel Reduction Gear High Speed Motor 3D Printer Parts
 # https://fr.aliexpress.com/item/1005006950563760.html?spm=a2g0o.order_list.order_list_main.628.1b995e5bbzDnya&gatewayAdapt=glo2fra
-resistance: 13
-inductance: 0.001
-holding_torque: 0.12
-max_current: 0.5
-steps_per_revolution: 200
+motor: fysetc-g36hsy4407-6d-1200a
+deprecated: false 
 
 [motor_alias generic-36BYGH-36HS2418CL16]
 # NEMA14 Round Pancake Stepper Motor 36BYGH / 36HS2418CL16 1.8° 0.18Nm for Voron 3D Printer Orbiter Extruder

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -1600,3 +1600,39 @@ inductance: 0.0037
 holding_torque: 0.420
 max_current: 1.50
 steps_per_revolution: 200
+
+### Tronxy Motors ###
+
+## NEMA17 ##
+[motor_constants SL42STH40-1684A]
+# SL42STH40-1684A 1.8A 78Oz-in 42 stepper motor
+# https://www.tronxyonline.com/SL42STH40-1684A-1-8A-78Oz-in-42-stepper-motor-p64966.html?variant=PJ-42JDJ-5P
+# https://forum.duet3d.com/assets/uploads/files/1694961895301-sl42sth40-1684a-23%E7%94%B5%E6%9C%BA%E5%9B%BE.pdf
+resistance: 1.2
+inductance: 0.0022
+holding_torque: 0.380
+max_current: 1.7
+steps_per_revolution: 200
+
+[motor_constants 42SHDC4080Z1-25B]
+# 42SHDC4080Z1-25B stepper motor
+# https://www.bodegaaurrera.com.mx/ip/motos/1pc-42-motor-paso-a-paso-motor-paso-a-paso-hibrido-de-alto-par-2-fases-1-8-grados-angulo-de-carevas-motor-paso-a-paso/00075290446288
+# https://www.amazon.ae/Stepper-Torque-Hybrid-Stepping-Printer/dp/B0C6M3B9HD
+resistance: 1.5
+inductance: 0.0028
+holding_torque: 0.40
+max_current: 1.68
+steps_per_revolution: 200
+
+
+### For Voron 2.4 - ALIEXPRESS ###
+
+## NEMA14 ##
+[motor_constants 6BYG1204-A-6QHT]
+# Voron 2.4 NEMA14 36mm moteur rond crêpe 6BYG1204-A-6QHT pour Orbiter Sherpa imprimante 3D Voron Mini extrudeuse
+# https://fr.aliexpress.com/item/1005006950563760.html?spm=a2g0o.order_list.order_list_main.628.1b995e5bbzDnya&gatewayAdapt=glo2fra
+resistance: 13
+inductance: 0.01
+holding_torque: 0.45
+max_current: 0.5
+steps_per_revolution: 200

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -1604,7 +1604,7 @@ steps_per_revolution: 200
 ### Tronxy Motors ###
 
 ## NEMA17 ##
-[motor_constants SL42STH40-1684A]
+[motor_constants tronxy-sl42sth40-1684a]
 # SL42STH40-1684A 1.8A 78Oz-in 42 stepper motor
 # https://www.tronxyonline.com/SL42STH40-1684A-1-8A-78Oz-in-42-stepper-motor-p64966.html?variant=PJ-42JDJ-5P
 # https://forum.duet3d.com/assets/uploads/files/1694961895301-sl42sth40-1684a-23%E7%94%B5%E6%9C%BA%E5%9B%BE.pdf
@@ -1614,7 +1614,7 @@ holding_torque: 0.380
 max_current: 1.7
 steps_per_revolution: 200
 
-[motor_constants 42SHDC4080Z1-25B]
+[motor_constants tronxy-42shdc4080z1-25b]
 # 42SHDC4080Z1-25B stepper motor
 # https://www.bodegaaurrera.com.mx/ip/motos/1pc-42-motor-paso-a-paso-motor-paso-a-paso-hibrido-de-alto-par-2-fases-1-8-grados-angulo-de-carevas-motor-paso-a-paso/00075290446288
 # https://www.amazon.ae/Stepper-Torque-Hybrid-Stepping-Printer/dp/B0C6M3B9HD
@@ -1625,14 +1625,25 @@ max_current: 1.68
 steps_per_revolution: 200
 
 
-### For Voron 2.4 - ALIEXPRESS ###
+### for Voron 3D - aliexpress ###
 
 ## NEMA14 ##
-[motor_constants 6BYG1204-A-6QHT]
-# Voron 2.4 NEMA14 36mm moteur rond crêpe 6BYG1204-A-6QHT pour Orbiter Sherpa imprimante 3D Voron Mini extrudeuse
+[motor_constants voron-6byg1204-a-6qht]
+# For CR10 CR 10S Ender3 V2 VORON HGX LITE Extruder Dual Gear Extruder Hard Steel Reduction Gear High Speed Motor 3D Printer Parts
 # https://fr.aliexpress.com/item/1005006950563760.html?spm=a2g0o.order_list.order_list_main.628.1b995e5bbzDnya&gatewayAdapt=glo2fra
 resistance: 13
-inductance: 0.01
+inductance: 0.001
 holding_torque: 0.45
 max_current: 0.5
+steps_per_revolution: 200
+
+[motor_constants voron-36bygh-36hs2418cl16]
+# NEMA14 Round Pancake Stepper Motor 36BYGH / 36HS2418CL16 1.8° 0.18Nm for Voron 3D Printer Orbiter Extruder
+# https://www.steppermotor.fr/goods-1724-NEMA14-Round-Pancake-Stepper-Motor-36BYGH--36HS2418CL16-18%C2%B0-018Nm-for-Voron-3D-Printer-Orbiter-Extruder.html
+# https://www.robotdigg.com/product/1995/
+# https://fr.aliexpress.com/item/1005010050935259.html?spm=a2g0o.productlist.main.4.27bcXHrMXHrM7Q&algo_pvid=0c6aae76-e49f-4364-9a74-6c863c3513f4&pdp_ext_f=%7B%22order%22%3A%2265%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005010050935259%7C_p_origin_prod%3A
+resistance: 1.85
+inductance: 0.00105
+holding_torque: 0.13
+max_current: 1.88
 steps_per_revolution: 200

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -1604,20 +1604,18 @@ steps_per_revolution: 200
 ### Tronxy Motors ###
 
 ## NEMA17 ##
-[motor_constants tronxy-sl42sth40-1684a]
+[motor_constants tronxy-SL42STH40-1684A]
 # SL42STH40-1684A 1.8A 78Oz-in 42 stepper motor
 # https://www.tronxyonline.com/SL42STH40-1684A-1-8A-78Oz-in-42-stepper-motor-p64966.html?variant=PJ-42JDJ-5P
-# https://forum.duet3d.com/assets/uploads/files/1694961895301-sl42sth40-1684a-23%E7%94%B5%E6%9C%BA%E5%9B%BE.pdf
 resistance: 1.2
 inductance: 0.0022
 holding_torque: 0.380
 max_current: 1.7
 steps_per_revolution: 200
 
-[motor_constants tronxy-42shdc4080z1-25b]
+[motor_constants tronxy-42SHDC4080Z1-25B]
 # 42SHDC4080Z1-25B stepper motor
 # https://www.bodegaaurrera.com.mx/ip/motos/1pc-42-motor-paso-a-paso-motor-paso-a-paso-hibrido-de-alto-par-2-fases-1-8-grados-angulo-de-carevas-motor-paso-a-paso/00075290446288
-# https://www.amazon.ae/Stepper-Torque-Hybrid-Stepping-Printer/dp/B0C6M3B9HD
 resistance: 1.5
 inductance: 0.0028
 holding_torque: 0.40
@@ -1625,25 +1623,20 @@ max_current: 1.68
 steps_per_revolution: 200
 
 
-### for Voron 3D - aliexpress ###
+### generic - for Voron 3D ###
 
 ## NEMA14 ##
-[motor_constants voron-6byg1204-a-6qht]
+[motor_constants generic-6BYG1204-A-6QHT]
 # For CR10 CR 10S Ender3 V2 VORON HGX LITE Extruder Dual Gear Extruder Hard Steel Reduction Gear High Speed Motor 3D Printer Parts
 # https://fr.aliexpress.com/item/1005006950563760.html?spm=a2g0o.order_list.order_list_main.628.1b995e5bbzDnya&gatewayAdapt=glo2fra
 resistance: 13
 inductance: 0.001
-holding_torque: 0.45
+holding_torque: 0.12
 max_current: 0.5
 steps_per_revolution: 200
 
-[motor_constants voron-36bygh-36hs2418cl16]
+[motor_alias generic-36BYGH-36HS2418CL16]
 # NEMA14 Round Pancake Stepper Motor 36BYGH / 36HS2418CL16 1.8° 0.18Nm for Voron 3D Printer Orbiter Extruder
-# https://www.steppermotor.fr/goods-1724-NEMA14-Round-Pancake-Stepper-Motor-36BYGH--36HS2418CL16-18%C2%B0-018Nm-for-Voron-3D-Printer-Orbiter-Extruder.html
 # https://www.robotdigg.com/product/1995/
-# https://fr.aliexpress.com/item/1005010050935259.html?spm=a2g0o.productlist.main.4.27bcXHrMXHrM7Q&algo_pvid=0c6aae76-e49f-4364-9a74-6c863c3513f4&pdp_ext_f=%7B%22order%22%3A%2265%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005010050935259%7C_p_origin_prod%3A
-resistance: 1.85
-inductance: 0.00105
-holding_torque: 0.13
-max_current: 1.88
-steps_per_revolution: 200
+motor: wantai-36HS2418 
+deprecated: false 


### PR DESCRIPTION
normalize motor name :
TRONXY :
SL42STH40-1684A -> tronxy-sl42sth40-1684a
42SHDC4080Z1-25B -> tronxy-42shdc4080z1-25b

for VORON 3D :
6BYG1204-A-6QHT -> voron-6byg1204-a-6qht (correcting inductance)

adding refence :
voron-36bygh-36hs2418cl16 - 36BYGH / 36HS2418CL16