### PR TITLE
Add Bondtech LGX and LGX PRO motor configurations

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -1226,6 +1226,38 @@ holding_torque: 0.40
 max_current: 1.70
 steps_per_revolution: 200
 
+## NEMA23 motors
+
+[motor_constants motech-mt-2305hs280aw]
+# Motech MT-2305HS280AW
+# Closest available datasheet match for MT-2305HS280A29-S.
+# 2.80 A/phase, 1.13 Ohm/phase, 3.6 mH/phase, 265 oz.in holding torque.
+resistance: 1.13
+inductance: 0.0036
+holding_torque: 1.87
+max_current: 2.80
+steps_per_revolution: 200
+
+[motor_alias motech-mt-2305hs280a29-s]
+# Modix/Motech variant. Assumed same electrical motor as MT-2305HS280AW.
+motor: motech-mt-2305hs280aw
+deprecated: false
+
+[motor_constants motech-mt-2303hs280aw]
+# Motech MT-2303HS280AW
+# Closest available datasheet match for MT-2303HS280A28-S.
+# 2.80 A/phase, 0.90 Ohm/phase, 2.5 mH/phase, 175 oz.in holding torque.
+resistance: 0.90
+inductance: 0.0025
+holding_torque: 1.24
+max_current: 2.80
+steps_per_revolution: 200
+
+[motor_alias motech-mt-2303hs280a28-s]
+# Modix/Motech variant. Assumed same electrical motor as MT-2303HS280AW.
+motor: motech-mt-2303hs280aw
+deprecated: false
+
 ### Oukeda Motors ###
 
 ## NEMA14

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -997,6 +997,30 @@ holding_torque: 0.100
 max_current: 1.2
 steps_per_revolution: 200
 
+### Bondtech Motors ###
+
+[motor_constants bondtech-42h030h-1504a-001]
+# Bondtech LGX PRO / NEMA17 Pancake Stepper 30mm / 14T Pressed Gear / SKU 13014A
+# Source: Bondtech 42H030H-1504A-001 datasheet. Rated current is specified as 1.5 A peak. :contentReference[oaicite:0]{index=0}
+resistance: 2.85
+inductance: 0.0038
+holding_torque: 0.294
+max_current: 1.5
+steps_per_revolution: 200
+
+[motor_alias bondtech-lgx-pro]
+motor: bondtech-42h030h-1504a-001
+deprecated: false
+
+[motor_alias bondtech-13014a]
+motor: bondtech-42h030h-1504a-001
+deprecated: false
+
+[motor_alias bondtech-lgx]
+# Bondtech LGX (big) motor that is in fact a rebranded LDO motor
+motor: ldo-42sth25-1004acg
+deprecated: false
+
 [motor_constants bondtech-42H025H-0704A-005]
 # Bondtech LGX https://www.bondtech.se/downloads/TDS/Bondtech-LGX-Motor-42H025H-0704-002.pdf
 resistance: 4.4

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -1001,25 +1001,12 @@ steps_per_revolution: 200
 
 [motor_constants bondtech-42h030h-1504a-001]
 # Bondtech LGX PRO / NEMA17 Pancake Stepper 30mm / 14T Pressed Gear / SKU 13014A
-# Source: Bondtech 42H030H-1504A-001 datasheet. Rated current is specified as 1.5 A peak. :contentReference[oaicite:0]{index=0}
+# Source: Bondtech 42H030H-1504A-001 datasheet.
 resistance: 2.85
 inductance: 0.0038
 holding_torque: 0.294
 max_current: 1.5
 steps_per_revolution: 200
-
-[motor_alias bondtech-lgx-pro]
-motor: bondtech-42h030h-1504a-001
-deprecated: false
-
-[motor_alias bondtech-13014a]
-motor: bondtech-42h030h-1504a-001
-deprecated: false
-
-[motor_alias bondtech-lgx]
-# Bondtech LGX (big) motor that is in fact a rebranded LDO motor
-motor: ldo-42sth25-1004acg
-deprecated: false
 
 [motor_constants bondtech-42H025H-0704A-005]
 # Bondtech LGX https://www.bondtech.se/downloads/TDS/Bondtech-LGX-Motor-42H025H-0704-002.pdf
@@ -1238,25 +1225,6 @@ holding_torque: 1.87
 max_current: 2.80
 steps_per_revolution: 200
 
-[motor_alias motech-mt-2305hs280a29-s]
-# Modix/Motech variant. Assumed same electrical motor as MT-2305HS280AW.
-motor: motech-mt-2305hs280aw
-deprecated: false
-
-[motor_constants motech-mt-2303hs280aw]
-# Motech MT-2303HS280AW
-# Closest available datasheet match for MT-2303HS280A28-S.
-# 2.80 A/phase, 0.90 Ohm/phase, 2.5 mH/phase, 175 oz.in holding torque.
-resistance: 0.90
-inductance: 0.0025
-holding_torque: 1.24
-max_current: 2.80
-steps_per_revolution: 200
-
-[motor_alias motech-mt-2303hs280a28-s]
-# Modix/Motech variant. Assumed same electrical motor as MT-2303HS280AW.
-motor: motech-mt-2303hs280aw
-deprecated: false
 
 ### Oukeda Motors ###
 

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -1213,18 +1213,6 @@ holding_torque: 0.40
 max_current: 1.70
 steps_per_revolution: 200
 
-## NEMA23 motors
-
-[motor_constants motech-mt-2305hs280aw]
-# Motech MT-2305HS280AW
-# Closest available datasheet match for MT-2305HS280A29-S.
-# 2.80 A/phase, 1.13 Ohm/phase, 3.6 mH/phase, 265 oz.in holding torque.
-resistance: 1.13
-inductance: 0.0036
-holding_torque: 1.87
-max_current: 2.80
-steps_per_revolution: 200
-
 
 ### Oukeda Motors ###
 


### PR DESCRIPTION
Adds Bondtech motor entries to motor_database.cfg.

Included:
- Bondtech LGX PRO motor constants for 42H030H-1504A-001 / SKU 13014A.
- Aliases for common LGX PRO names.
- Bondtech LGX aliases pointing to the existing ldo-42sth25-1004acg entry, since the LGX motor is already listed as a rebranded LDO motor.

The LGX PRO values are based on the Bondtech motor datasheet.