### PR TITLE
use absolute path lookup to enable installing from any directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 KLIPPER_PATH="${HOME}/klipper"
-AUTOTUNETMC_PATH="${HOME}/klipper_tmc_autotune"
+AUTOTUNETMC_PATH="$(dirname "$(readlink -f "$0")")"
 
 if [[ -e ${KLIPPER_PATH}/klippy/plugins/ ]]; then
     KLIPPER_PLUGINS_PATH="${KLIPPER_PATH}/klippy/plugins/"


### PR DESCRIPTION
Why:
- I keep all my klipper modules in their own directory to keep home clean, but using the static AUTOTUNETMC_PATH path breaks that flexibility. 

Change:
- This change just extracts the absolute path to the directory the install script is in, and sets it to the "AUTOTUNETMC_PATH" variable. This allows the repo to be cloned anywhere, and still install correctly. 