### PR TITLE
Add Excit3D Max Motor to database

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -1609,6 +1609,13 @@ holding_torque: 0.56
 max_current: 4.0
 steps_per_revolution: 200
 
+[motor_alias excit3d-max-motor]
+# Shares the same electrical specs as the above motor
+# https://excit3d.shop/shop/excit3d-max-motor
+# https://excit3d.shop/uploads/1776344140987-490266.png
+motor: shengyang-42bygh3025-4m-25d
+deprecated: false
+
 [motor_constants rattm-17HS8401]
 # https://www.aliexpress.com/item/517614158.html / https://www.voxelfactory.com/products/nema17-stepper-motor-17hs8401
 resistance: 1.8


### PR DESCRIPTION
While this motor has a longer round shaft and upgraded internals, all the electrical specs autotune cares about are identical to an existing motor by the same manufacturer so just use that one.