### PR TITLE
fix: reject unsafe overvoltage_vth values

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ All the `[autotune_tmc]` sections accept additional parameters to tweak the beha
 | seimin | 1 | 0 to 1 | **Coolstep**: Sets the lower motor current limit for CoolStep operation by scaling the run current. 0 = 50%, 1 = 25% of run current. |
 | pwm_freq_target | varies | 10e3 to 60e3 | Switching frequency target, in Hz. The code selects the highest available PWM frequency at or below this target, which usually results in 48 kHz switching. Defaults to 55 kHz for TMC2130/2208/2209 and 20 kHz for TMC2240/2660/5160 to avoid excessive driver heat. |
 | voltage | 24 | 0.0 to 60.0 | Voltage used to power this motor and stepper driver |
-| overvoltage_vth |  | 0.0 to 60.0 | Set the optional overvoltage snubber built into the TMC2240 and TMC5160. Users of the BTT SB2240 toolhead board should use it for the extruder by reading the actual toolhead voltage and adding 0.8V |
+| overvoltage_vth |  | above 0.0 to 41.0 | Set the optional overvoltage snubber built into the TMC2240 and TMC5160. Users of the BTT SB2240 toolhead board should use it for the extruder by reading the actual toolhead voltage and adding 0.8V |
 
 Also if needed, you can adjust everything on the go when the printer is running by using the `AUTOTUNE_TMC` macro in the Klipper console. All previous parameters are available:
 ```

--- a/autotune_tmc.py
+++ b/autotune_tmc.py
@@ -170,8 +170,11 @@ class AutotuneTMC:
         self.voltage = config.getfloat(
             "voltage", default=VOLTAGE, minval=0.0, maxval=60.0
         )
+        # A zero threshold asserts the overvoltage condition continuously, and
+        # values above the TMC2240 absolute maximum cannot protect it in time.
+        # Leaving the option unset preserves the driver's hardware default.
         self.overvoltage_vth = config.getfloat(
-            "overvoltage_vth", default=OVERVOLTAGE_VTH, minval=0.0, maxval=60.0
+            "overvoltage_vth", default=OVERVOLTAGE_VTH, above=0.0, maxval=41.0
         )
         self.pwm_freq_target = config.getfloat(
             "pwm_freq_target",
@@ -309,11 +312,11 @@ class AutotuneTMC:
                 gcmd.respond_info("VOLTAGE=%.1f out of range (0-60), ignored" % voltage)
         overvoltage_vth = gcmd.get_float("OVERVOLTAGE_VTH", None)
         if overvoltage_vth is not None:
-            if overvoltage_vth >= 0.0 and overvoltage_vth <= 60.0:
+            if overvoltage_vth > 0.0 and overvoltage_vth <= 41.0:
                 self.overvoltage_vth = overvoltage_vth
             else:
                 gcmd.respond_info(
-                    "OVERVOLTAGE_VTH=%.1f out of range (0-60), ignored"
+                    "OVERVOLTAGE_VTH=%.1f out of range (0-41), ignored"
                     % overvoltage_vth
                 )
         self.tune_driver()
@@ -324,6 +327,22 @@ class AutotuneTMC:
         # Validate before any hardware write: out-of-range values would be masked
         # into the 8-bit fields and also drive maxpwmrps() negative.
         self._check_pwm_field_ranges()
+        # Program the overvoltage threshold before any other register write, so a
+        # rejected value cannot leave the driver partially retuned. Quantize
+        # upward and validate the value that actually reaches the register: a
+        # flooring conversion could otherwise program a threshold below the supply
+        # and assert the overvoltage condition continuously. Done here rather than
+        # at parse time so a runtime VOLTAGE change is also covered.
+        if self.overvoltage_vth is not None:
+            vth = int(math.ceil(self.overvoltage_vth / 0.009732))
+            if vth * 0.009732 <= self.voltage:
+                raise self.printer.command_error(
+                    "Autotune %s: overvoltage_vth=%.3f V programs %.3f V, which "
+                    "does not exceed the supply voltage %.1f V; the overvoltage "
+                    "condition would assert continuously."
+                    % (self.name, self.overvoltage_vth, vth * 0.009732, self.voltage)
+                )
+            self._set_overvoltage_vth(vth)
         self._set_pwmfreq()
         self._setup_spreadcycle()
         self._set_hysteresis(self.run_current)
@@ -336,9 +355,6 @@ class AutotuneTMC:
         # Speed at which we run out of PWM control and should switch to fullstep
         vmaxpwm = maxpwmrps * rdist
         logging.info("autotune_tmc using max PWM speed %f", vmaxpwm)
-        if self.overvoltage_vth is not None:
-            vth = int(self.overvoltage_vth / 0.009732)
-            self._set_overvoltage_vth(vth)
         coolthrs = COOLSTEP_THRS_FACTOR * rdist
         self._setup_pwm(self.tuning_goal, self._pwmthrs(vmaxpwm, coolthrs))
         # One revolution every two seconds is about as slow as coolstep can go

--- a/docs/example.cfg
+++ b/docs/example.cfg
@@ -44,7 +44,9 @@ sg4_thrs: 10
 # Default: 24
 voltage: 24
 # Set the optional overvoltage snubber built into the TMC2240 and TMC5160. Users of the BTT SB2240 toolhead board should use it
-# for the extruder by reading the actual toolhead voltage and adding 0.8V
-# Values: 0.0 to 60.0
-# Default: 0.0
-overvoltage_vth: 0.0
+# for the extruder by reading the actual toolhead voltage and adding 0.8V.
+# Set this above the supply voltage. A value of 0 asserts the overvoltage condition
+# continuously and is not accepted. Leave the option unset to keep the driver default.
+# Values: above 0.0, up to 41.0 (TMC2240 absolute maximum)
+# Default: unset (driver hardware default is preserved)
+#overvoltage_vth: 28.0


### PR DESCRIPTION
## Summary

Safety fix for the TMC2240 `overvoltage_vth` option. The current code accepts
thresholds that make the driver assert its overvoltage condition continuously —
including `0`, values above the part's ratings, and values at or below the supply
voltage. If the OV output drives a brake/dump-load circuit (as in the datasheet
example), that load can stay energized.

## Problem

The TMC2240 asserts overvoltage whenever `ADC_VSUPPLY >= OVERVOLTAGE_VTH`. Three
ways the old handling let that stay true:

- `overvoltage_vth: 0.0` converts to register `0` → always asserted. The example
  config even shipped `overvoltage_vth: 0.0`.
- The `0.0–60.0 V` range accepted values above the 41 V absolute maximum, where
  the threshold can't protect the driver in time.
- Any threshold at or below the supply asserts continuously. Validating the
  *requested* value wasn't enough either: the register quantizes in 9.732 mV
  steps, and a flooring conversion could program a value just under the supply
  (`24.001 V` → `23.999 V`).

## Fix

- Parse `overvoltage_vth` with `above=0.0` and `maxval=41.0`; apply the same
  bounds to the `AUTOTUNE_TMC` runtime command.
- At the **start** of `tune_driver()`, before any other register write: quantize
  the threshold upward (`ceil`) and reject it unless the value that actually
  reaches the register exceeds the supply. Running it first means a rejected
  value can't leave the driver partially retuned; doing it at apply time also
  covers runtime `VOLTAGE` changes.
- Drop `overvoltage_vth: 0.0` from `docs/example.cfg` and fix the documented
  range in the README and example.

Omitting the option is unchanged — it still preserves the driver's hardware
default (config default is `None`, guarded before any write).

## Compatibility

No change for configs that omit the option or set a safe threshold. A config that
relied on `overvoltage_vth: 0.0`, a value >41 V, or a value ≤ supply now fails
loudly instead of silently mis-programming — `config.error` at startup,
`gcmd.error` from the runtime command.

## Verification

- `ruff check` / `ruff format --check` pass.
- Quantization checked numerically: `24.001 V @ 24.0 V` supply now programs
  `24.0088 V` (above supply) rather than the old `23.999 V`; a genuinely
  below-supply request (e.g. `5 V @ 24 V`) is rejected.

## Notes

Source: TMC2240 datasheet — OV comparison `ADC_VSUPPLY >= OVERVOLTAGE_VTH`
(pp. 65–66), 36 V operating / 41 V absolute-max supply (p. 9), 9.732 mV/count.
