### PR TITLE
fix: reject PWM register values that overflow the 8-bit field

### DIFF
--- a/autotune_tmc.py
+++ b/autotune_tmc.py
@@ -321,6 +321,9 @@ class AutotuneTMC:
     def tune_driver(self):
         _currents = self.tmc_cmdhelper.current_helper.get_current()
         self.run_current = _currents[0]
+        # Validate before any hardware write: out-of-range values would be masked
+        # into the 8-bit fields and also drive maxpwmrps() negative.
+        self._check_pwm_field_ranges()
         self._set_pwmfreq()
         self._setup_spreadcycle()
         self._set_hysteresis(self.run_current)
@@ -342,6 +345,34 @@ class AutotuneTMC:
         self._set_driver_field("multistep_filt", MULTISTEP_FILT)
         # Cool down 2240s
         self._set_driver_field("slope_control", SLOPE_CONTROL)
+
+    def _check_pwm_field_ranges(self):
+        # PWM_OFS and PWM_GRAD are 8-bit fields. Klipper's FieldHelper.set_field()
+        # masks values into the field width rather than validating them, so an
+        # out-of-range result would wrap. Drivers without StealthChop (e.g.
+        # tmc2660) have neither field, so skip a check when the field is absent.
+        motor = self.motor_object
+        fields = self.tmc_object.fields
+        if fields.lookup_register("pwm_ofs", None) is not None:
+            # PWM_OFS must stay below 255: at 255 there is no headroom and
+            # maxpwmrps() collapses to zero. It scales with run current.
+            pwm_ofs = motor.pwmofs(volts=self.voltage, current=self.run_current)
+            if not 0 <= pwm_ofs < 255:
+                raise self.printer.command_error(
+                    "Autotune %s: computed PWM_OFS=%d leaves no headroom below "
+                    "the 8-bit limit for motor '%s' at %.1f V and %.2f A. Lower "
+                    "the run current or raise the supply voltage."
+                    % (self.name, pwm_ofs, self.motor, self.voltage, self.run_current)
+                )
+        if fields.lookup_register("pwm_grad", None) is not None:
+            # PWM_GRAD depends on back-EMF and supply voltage, not run current.
+            pwm_grad = motor.pwmgrad(volts=self.voltage, fclk=self.fclk)
+            if not 0 <= pwm_grad <= 255:
+                raise self.printer.command_error(
+                    "Autotune %s: computed PWM_GRAD=%d exceeds the 8-bit field "
+                    "for motor '%s' at %.1f V. Raise the supply voltage."
+                    % (self.name, pwm_grad, self.motor, self.voltage)
+                )
 
     def _set_driver_field(self, field, arg):
         tmco = self.tmc_object


### PR DESCRIPTION
## Summary

`motor_constants.pwmofs()` and `pwmgrad()` return unbounded integers, but
`PWM_OFS` and `PWM_GRAD` are 8-bit driver fields. Out-of-range values are
currently masked into the field and silently wrap. This adds a range check before
any register write and turns an unrepresentable operating point into an
actionable error.

## Problem

Klipper's `FieldHelper.set_field()` masks a value into the field width instead of
validating it:

```python
new_value = (reg_value & ~mask) | ((field_value << ffs(mask)) & mask)
```

So a 10 Ω motor at 1 A / 12 V computes `PWM_OFS = 312`, which is written as `56`.
Worse, `maxpwmrps()` uses the unmasked `312` in `(255 - PWM_OFS)`, returns a
negative velocity, and Klipper converts a non-positive velocity to a `TSTEP`
threshold of `0xfffff` — disabling StealthChop and CoolStep for nearly all motion.

## Fix

`_check_pwm_field_ranges()` runs at the **start** of `tune_driver()`, before any
hardware write, and raises a `command_error` naming the motor and operating point:

- Each field is checked only if the driver actually has it. Drivers without
  StealthChop (e.g. tmc2660 has neither `pwm_ofs` nor `pwm_grad`) are not rejected
  for values that would never be written.
- `PWM_OFS` must be strictly below 255 — at 255 there is no headroom and
  `maxpwmrps()` collapses to zero.
- Remediation is field-specific: `PWM_OFS` scales with run current and supply
  voltage; `PWM_GRAD` depends on back-EMF and supply voltage, not run current.

## Compatibility

No change for motor/voltage combinations that already fit the 8-bit fields. A
combination that previously wrapped (or drove `maxpwmrps()` negative) now fails
loudly instead of silently mis-tuning.

## Verification

`ruff check` / `ruff format --check` pass. The failing example above
(`PWM_OFS = 312`) and the zero-headroom case (`PWM_OFS = 255`, e.g. a 10 Ω motor
at ~0.818 A / 12 V) are both rejected; in-range values are unaffected.

## Notes

Source: TMC2209 rev1.09, TMC2240, TMC5160A rev1.18, TMC2130 rev1.15 register maps
(8-bit `PWM_OFS`/`PWM_GRAD`; tmc2660 has neither); Klipper `FieldHelper.set_field`
masking behavior.
