### PR TITLE
fix: pass driver clock to maxpwmrps

### DIFF
--- a/autotune_tmc.py
+++ b/autotune_tmc.py
@@ -326,7 +326,9 @@ class AutotuneTMC:
         self._set_hysteresis(self.run_current)
         self._set_sg4thrs()
         motor = self.motor_object
-        maxpwmrps = motor.maxpwmrps(volts=self.voltage, current=self.run_current)
+        maxpwmrps = motor.maxpwmrps(
+            fclk=self.fclk, volts=self.voltage, current=self.run_current
+        )
         rdist, _ = self.tmc_cmdhelper.stepper.get_rotation_distance()
         # Speed at which we run out of PWM control and should switch to fullstep
         vmaxpwm = maxpwmrps * rdist


### PR DESCRIPTION
## Summary

`tune_driver()` computed the max-PWM velocity from `maxpwmrps()` without passing
the driver clock, so it used the function's `12.5 MHz` default while the
`PWM_GRAD` register written later uses the clock Klipper actually reports. The two
were derived from different frequencies. This passes `fclk` so they agree.

## Problem

`motor_constants.maxpwmrps()` defaults `fclk=12.5e6`. The caller omitted it:

```python
maxpwmrps = motor.maxpwmrps(volts=self.voltage, current=self.run_current)
```

Klipper reports 12 MHz for the local tmc2209/tmc5160 definitions, and `PWM_GRAD`
is computed with that reported clock. So the velocity limit (`vmaxpwm`, and the
thresholds derived from it) and the PWM register values came from inconsistent
clocks.

## Fix

Pass `fclk=self.fclk` into the `maxpwmrps()` call so the velocity limit uses the
same clock as the register math. Scoped to the clock inconsistency only.

## Notes

Source: Klipper TMC frequency definitions vs `motor_constants.maxpwmrps` default
`fclk=12.5e6`