### PR TITLE
fix: use correct slow-decay base time in hysteresis model

### DIFF
--- a/motor_constants.py
+++ b/motor_constants.py
@@ -45,7 +45,8 @@ class MotorConstants:
     ):
         effective_current = current if current > 0.0 else self.max_current
         logging.info("autotune_tmc setting hysteresis based on %s V", volts)
-        tsd = (12.0 + 32.0 * toff) / fclk
+        # Slow decay phase duration NCLK = 24 + 32*TOFF per the CHOPCONF register.
+        tsd = (24.0 + 32.0 * toff) / fclk
         dcoilblank = volts * (tblank_cycles / fclk) / self.coil_inductance
         dcoilsd = (
             self.coil_resistance * effective_current * 2.0 * tsd / self.coil_inductance


### PR DESCRIPTION
## Summary

The hysteresis calculation modeled each SpreadCycle slow-decay phase as
`12 + 32*TOFF` clocks. The CHOPCONF `TOFF` register description specifies
`NCLK = 24 + 32*TOFF`. This corrects the base to 24.

## Problem

`motor_constants.hysteresis()` used:

```python
tsd = (12.0 + 32.0 * toff) / fclk
```

The automatic `TOFF` and TPFD math elsewhere in the code already uses 24, so the
two timing models were internally inconsistent. At `TOFF=1` the model counted 44
clocks per slow-decay phase instead of 56, underestimating the resistive current
decay and potentially selecting too little hysteresis.

## Fix

Use `24 + 32*TOFF`, a single shared base. 24 is correct for every supported
driver:

- TMC2209 rev1.09, TMC2240, TMC5160A rev1.18, and TMC2130 rev1.15 all specify 24
  in their CHOPCONF register tables.
- The older TMC2660 rev1.07 register table printed 12 (contradicted by a later
  section in the same document). The current TMC2660/TMC2660C rev1.03 datasheet
  resolves this and is self-consistent at 24 across the register table, the second
  CHOPCONF section, and the starting-value example.

So no driver-specific handling is needed.

## Notes

This changes the computed HSTRT/HEND for existing configs slightly (e.g. one case
went from `(7, 7)` to `(7, 8)`), toward the datasheet-specified value.
