### PR TITLE
fix: use correct faststandstill field name

### DIFF
--- a/autotune_tmc.py
+++ b/autotune_tmc.py
@@ -530,7 +530,7 @@ class AutotuneTMC:
     def _setup_coolstep(self, coolthrs):
         self._set_driver_velocity_field("tcoolthrs", coolthrs)
         self._set_driver_field("sgt", self.sgt)
-        self._set_driver_field("fast_standstill", FAST_STANDSTILL)
+        self._set_driver_field("faststandstill", FAST_STANDSTILL)
         self._set_driver_field("small_hysteresis", SMALL_HYSTERESIS)
         self._set_driver_field("semin", self.se_min)
         self._set_driver_field("semax", self.se_max)


### PR DESCRIPTION
## Summary

Autotune wrote a `fast_standstill` field that doesn't exist. Klipper names the
TMC2240/TMC5160 field `faststandstill` (no underscore), so the write silently did
nothing and the intended fast-standstill timeout was never applied.

## Problem

```python
self._set_driver_field("fast_standstill", FAST_STANDSTILL)
```

`_set_driver_field()` looks the field up and returns quietly when it doesn't
exist. Since the real field is `faststandstill`, this was a no-op — the driver
kept its default `2^20`-clock standstill timeout instead of the intended
`2^18`-clock one.

## Fix

Use the correct field name, `faststandstill`.

## Notes

Field name confirmed in Klipper: `klippy/extras/tmc2240.py` and
`klippy/extras/tmc5160.py`.
