### PR TITLE
fix: select PWM frequency at an exact target, not below it

### DIFF
--- a/autotune_tmc.py
+++ b/autotune_tmc.py
@@ -411,7 +411,7 @@ class AutotuneTMC:
         tmco.fields.set_field(field, arg)
 
     def _set_pwmfreq(self):
-        # calculate the highest pwm_freq below pwm_freq_target
+        # calculate the highest pwm_freq at or below pwm_freq_target
         pwm_freq = next(
             (
                 i
@@ -422,7 +422,7 @@ class AutotuneTMC:
                     (0, 2.0 / 1024),
                     (0, 0.0),  # Default case, just do the best we can.
                 ]
-                if self.fclk * i[1] < self.pwm_freq_target
+                if self.fclk * i[1] <= self.pwm_freq_target
             )
         )[0]
         self._set_driver_field("pwm_freq", pwm_freq)


### PR DESCRIPTION
## Summary

`_set_pwmfreq()` picked the highest `pwm_freq` strictly *below* the target, but
the README promises the highest frequency "at or below" the target. When a
setting lands exactly on the target, the strict comparison skipped it and dropped
to the next lower one.

## Problem

```python
if self.fclk * i[1] < self.pwm_freq_target
```

At a TMC2209 `pwm_freq_target` of exactly 46875 Hz (`12 MHz * 2/512`), the strict
`<` rejected `pwm_freq=2` and selected `pwm_freq=1` instead — about 35139 Hz,
noticeably below the requested switching frequency.

## Fix

Use `<=` so an exact match selects the higher (correct) frequency, matching the
documented "at or below" behavior.

## Notes

Matches the README `pwm_freq_target` description: "the highest available PWM
frequency at or below this target."
