### PR TITLE
fix: reject overvoltage_vth on drivers without the register

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ All the `[autotune_tmc]` sections accept additional parameters to tweak the beha
 | seimin | 1 | 0 to 1 | **Coolstep**: Sets the lower motor current limit for CoolStep operation by scaling the run current. 0 = 50%, 1 = 25% of run current. |
 | pwm_freq_target | varies | 10e3 to 60e3 | Switching frequency target, in Hz. The code selects the highest available PWM frequency at or below this target, which usually results in 48 kHz switching. Defaults to 55 kHz for TMC2130/2208/2209 and 20 kHz for TMC2240/2660/5160 to avoid excessive driver heat. |
 | voltage | 24 | 0.0 to 60.0 | Voltage used to power this motor and stepper driver |
-| overvoltage_vth |  | above 0.0 to 41.0 | Set the optional overvoltage snubber built into the TMC2240 and TMC5160. Users of the BTT SB2240 toolhead board should use it for the extruder by reading the actual toolhead voltage and adding 0.8V |
+| overvoltage_vth |  | above 0.0 to 41.0 | Set the optional overvoltage snubber built into the TMC2240. Users of the BTT SB2240 toolhead board should use it for the extruder by reading the actual toolhead voltage and adding 0.8V |
 
 Also if needed, you can adjust everything on the go when the printer is running by using the `AUTOTUNE_TMC` macro in the Klipper console. All previous parameters are available:
 ```

--- a/autotune_tmc.py
+++ b/autotune_tmc.py
@@ -176,6 +176,13 @@ class AutotuneTMC:
         self.overvoltage_vth = config.getfloat(
             "overvoltage_vth", default=OVERVOLTAGE_VTH, above=0.0, maxval=41.0
         )
+        # Only the TMC2240 has a programmable overvoltage threshold; reject the
+        # option on other drivers instead of silently ignoring it.
+        if self.overvoltage_vth is not None and self.driver_type != "tmc2240":
+            raise config.error(
+                "overvoltage_vth is only supported on TMC2240, but the driver "
+                "for '%s' is %s." % (self.name, self.driver_type)
+            )
         self.pwm_freq_target = config.getfloat(
             "pwm_freq_target",
             default=PWM_FREQ_TARGETS[self.driver_type],
@@ -312,7 +319,11 @@ class AutotuneTMC:
                 gcmd.respond_info("VOLTAGE=%.1f out of range (0-60), ignored" % voltage)
         overvoltage_vth = gcmd.get_float("OVERVOLTAGE_VTH", None)
         if overvoltage_vth is not None:
-            if overvoltage_vth > 0.0 and overvoltage_vth <= 41.0:
+            if self.driver_type != "tmc2240":
+                gcmd.respond_info(
+                    "OVERVOLTAGE_VTH is only supported on TMC2240, ignored"
+                )
+            elif overvoltage_vth > 0.0 and overvoltage_vth <= 41.0:
                 self.overvoltage_vth = overvoltage_vth
             else:
                 gcmd.respond_info(

--- a/docs/example.cfg
+++ b/docs/example.cfg
@@ -43,7 +43,7 @@ sg4_thrs: 10
 # Values: 0.0 to 60.0
 # Default: 24
 voltage: 24
-# Set the optional overvoltage snubber built into the TMC2240 and TMC5160. Users of the BTT SB2240 toolhead board should use it
+# Set the optional overvoltage snubber built into the TMC2240. Users of the BTT SB2240 toolhead board should use it
 # for the extruder by reading the actual toolhead voltage and adding 0.8V.
 # Set this above the supply voltage. A value of 0 asserts the overvoltage condition
 # continuously and is not accepted. Leave the option unset to keep the driver default.


### PR DESCRIPTION
## Summary

The README and example describe the built-in overvoltage snubber as available on
both TMC2240 and TMC5160, but only the TMC2240 has a programmable
`overvoltage_vth` register. Setting it on any other driver was silently ignored —
no error, no protection. This rejects the option where it isn't supported and
fixes the docs.

## Problem

`_set_overvoltage_vth()` looks the register up and returns quietly when it's
absent. On a TMC5160 (or TMC2209 etc.), a user could set `overvoltage_vth`,
believe they had overvoltage protection, and get nothing. The TMC5160 relies on
external supply protection instead.

## Fix

- Raise a config error when `overvoltage_vth` is set on any driver other than
  TMC2240 (at startup; the `AUTOTUNE_TMC` command rejects it with a message too).
- Drop the false "and TMC5160" from the README and example config — the option is
  TMC2240-only.

## Compatibility

No change for TMC2240 users or for any config that doesn't set `overvoltage_vth`.
A non-TMC2240 config that set the option (which did nothing before) now fails
loudly, pointing at the mistake.

## Notes

`overvoltage_vth` exists only in Klipper's `klippy/extras/tmc2240.py` (absent from
`tmc5160.py`, `tmc2209.py`, `tmc2130.py`). The TMC5160A rev1.18 datasheet
(section 3.1) describes external supply protection, with no programmable
overvoltage threshold.
