### PR TITLE
Revise motor constants for FLSUN 42BYGH718-B-27HQT

### DIFF
--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -1141,11 +1141,11 @@ max_current: 1.5
 steps_per_revolution: 200
 
 [motor_constants flsun-v400-42]
-# FLSUN 42BYGH718-B27HQT (V400) http://m.wantmotor.com/hybrid-stepper-motor/2-phases-hybrid-stepper-motor/42bygh-stepper-motor.html
-resistance: 18.00
-inductance: 0.023
-holding_torque: 0.284
-max_current: 0.5
+# FLSUN 42BYGH718-B-27HQT (V400) https://www.lazada.vn/products/dong-co-buoc-cho-may-in-3d-flsun-v400-axis-motor-4248-i2235316059.html
+resistance: 1.7
+inductance: 0.042
+holding_torque: 0.42
+max_current: 1.5
 steps_per_revolution: 200
 
 [motor_constants flsun-v400-36]

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -1142,10 +1142,10 @@ steps_per_revolution: 200
 
 [motor_constants flsun-v400-42]
 # FLSUN 42BYGH718-B-27HQT (V400) https://www.lazada.vn/products/dong-co-buoc-cho-may-in-3d-flsun-v400-axis-motor-4248-i2235316059.html
-resistance: 1.7
-inductance: 0.042
+resistance: 1.70
+inductance: 0.0042
 holding_torque: 0.42
-max_current: 1.5
+max_current: 1.50
 steps_per_revolution: 200
 
 [motor_constants flsun-v400-36]

--- a/motor_database.cfg
+++ b/motor_database.cfg
@@ -1140,12 +1140,20 @@ holding_torque: 0.37
 max_current: 1.5
 steps_per_revolution: 200
 
-[motor_constants flsun-v400-42]
+[motor_constants flsun-42bygh718-b-27hqt]
 # FLSUN 42BYGH718-B-27HQT (V400) https://www.lazada.vn/products/dong-co-buoc-cho-may-in-3d-flsun-v400-axis-motor-4248-i2235316059.html
 resistance: 1.70
 inductance: 0.0042
 holding_torque: 0.42
 max_current: 1.50
+steps_per_revolution: 200
+
+[motor_constants flsun-v400-42]
+# FLSUN 42BYGH718-B27HQT (V400) http://m.wantmotor.com/hybrid-stepper-motor/2-phases-hybrid-stepper-motor/42bygh-stepper-motor.html
+resistance: 18.00
+inductance: 0.023
+holding_torque: 0.284
+max_current: 0.5
 steps_per_revolution: 200
 
 [motor_constants flsun-v400-36]


### PR DESCRIPTION
Fix wrong specs for v400 steppers:
https://www.lazada.vn/products/dong-co-buoc-cho-may-in-3d-flsun-v400-axis-motor-4248-i2235316059.html

* Step angle: 1.8° ± 0.09°
* Current: DC 1.5A/Phase
* Phase resistance (20°C): 1.7x (1 ± 20%) Ω / phase
* Phase inductance (1KHz): 4.2x (1 ± 20%) mH/ phase
* Holding torque: ≥ 420mN.m
* Positioning torque: 20mN.m REF
* Weight: 369g
* Size: 42*42*48mm